### PR TITLE
Allow embedding kati build within early Android build

### DIFF
--- a/Makefile.ckati
+++ b/Makefile.ckati
@@ -12,9 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-KATI_CXX ?= $(CXX)
+# Find source file location from path to this Makefile
+KATI_SRC_PATH := $(patsubst %/,%,$(dir $(lastword $(MAKEFILE_LIST))))
 
-KATI_CXX_SRCS:= \
+# Set defaults if they weren't set by the including Makefile
+KATI_CXX ?= $(CXX)
+KATI_LD ?= $(CXX)
+KATI_INTERMEDIATES_PATH ?= .
+KATI_BIN_PATH ?= .
+
+KATI_CXX_SRCS := \
 	ast.cc \
 	command.cc \
 	dep.cc \
@@ -38,38 +45,65 @@ KATI_CXX_SRCS:= \
 	symtab.cc \
 	timeutil.cc \
 	value.cc \
-	var.cc \
+	var.cc
+
+KATI_CXX_GENERATED_SRCS := \
 	version.cc
-KATI_CXX_TEST_SRCS:= \
-	$(wildcard *_test.cc)
-KATI_CXX_OBJS:=$(KATI_CXX_SRCS:.cc=.o)
-KATI_CXX_TEST_OBJS:=$(KATI_CXX_TEST_SRCS:.cc=.o)
-KATI_CXX_ALL_OBJS:=$(KATI_CXX_SRCS:.cc=.o) $(KATI_CXX_TEST_SRCS:.cc=.o)
-KATI_CXX_TEST_EXES:=$(KATI_CXX_TEST_OBJS:.o=)
-KATI_CXXFLAGS:=-g -W -Wall -MMD
-KATI_CXXFLAGS+=-O -DNOLOG
-#KATI_CXXFLAGS+=-pg
 
-ckati: $(KATI_CXX_OBJS)
-	$(KATI_CXX) -std=c++11 $(KATI_CXXFLAGS) -o $@ $(KATI_CXX_OBJS)
+KATI_CXX_SRCS := $(addprefix $(KATI_SRC_PATH)/,$(KATI_CXX_SRCS))
+KATI_CXX_TEST_SRCS:= $(wildcard $(KATI_SRC_PATH)/*_test.cc)
 
-$(KATI_CXX_ALL_OBJS): %.o: %.cc
+KATI_CXX_OBJS := $(patsubst $(KATI_SRC_PATH)/%.cc,$(KATI_INTERMEDIATES_PATH)/%.o,\
+	$(KATI_CXX_SRCS))
+KATI_CXX_GENERATED_OBJS := $(patsubst %.cc,$(KATI_INTERMEDIATES_PATH)/%.o,\
+	$(KATI_CXX_GENERATED_SRCS))
+KATI_CXX_TEST_OBJS := $(patsubst $(KATI_SRC_PATH)/%.cc,$(KATI_INTERMEDIATES_PATH)/%.o,\
+	$(KATI_CXX_TEST_SRCS))
+
+KATI_CXX_TEST_EXES := $(patsubst $(KATI_INTERMEDIATES_PATH)/%.o,$(KATI_BIN_PATH)/%,\
+	$(KATI_CXX_TEST_OBJS))
+
+KATI_CXXFLAGS := -g -W -Wall -MMD -MP
+KATI_CXXFLAGS += -O -DNOLOG
+#KATI_CXXFLAGS += -pg
+
+# Rule to build ckati into KATI_BIN_PATH
+$(KATI_BIN_PATH)/ckati: $(KATI_CXX_OBJS) $(KATI_CXX_GENERATED_OBJS)
+	@mkdir -p $(dir $@)
+	$(KATI_LD) -std=c++11 $(KATI_CXXFLAGS) -o $@ $^
+
+# Rule to build normal source files into object files in KATI_INTERMEDIATES_PATH
+$(KATI_CXX_OBJS) $(KATI_CXX_TEST_OBJS): $(KATI_INTERMEDIATES_PATH)/%.o: $(KATI_SRC_PATH)/%.cc
+	@mkdir -p $(dir $@)
+	$(KATI_CXX) -c -std=c++11 $(KATI_CXXFLAGS) -o $@ $<
+
+# Rule to build generated source files into object files in KATI_INTERMEDIATES_PATH
+$(KATI_CXX_GENERATED_OBJS): $(KATI_INTERMEDIATES_PATH)/%.o: $(KATI_INTERMEDIATES_PATH)/%.cc
+	@mkdir -p $(dir $@)
 	$(KATI_CXX) -c -std=c++11 $(KATI_CXXFLAGS) -o $@ $<
 
 ckati_tests: $(KATI_CXX_TEST_EXES)
 
-$(KATI_CXX_TEST_EXES): $(filter-out main.o,$(KATI_CXX_OBJS))
-$(KATI_CXX_TEST_EXES): %: %.o
-	$(KATI_CXX) $^ -o $@
+# Rule to build tests using *_test.cc and all normal *.cc files except main.cc
+$(KATI_CXX_TEST_EXES): $(filter-out $(KATI_INTERMEDIATES_PATH)/main.o,$(KATI_CXX_OBJS)) $(KATI_CXX_GENERATED_OBJS)
+$(KATI_CXX_TEST_EXES): $(KATI_BIN_PATH)/%: $(KATI_INTERMEDIATES_PATH)/%.o
+	$(KATI_LD) $^ -o $@
 
-version.cc: .git/HEAD .git/index
+# Rule to generate version.cc
+KATI_GIT_DIR := $(shell cd $(KATI_SRC_PATH) && git rev-parse --show-toplevel)
+$(KATI_INTERMEDIATES_PATH)/version.cc: $(KATI_GIT_DIR)/.git/HEAD $(KATI_GIT_DIR)/.git/index
+	@mkdir -p $(dir $@)
 	echo '// +build ignore' > $@
 	echo >> $@
 	echo 'const char* kGitVersion = "$(shell git rev-parse HEAD)";' >> $@
 
 ckati_clean:
-	rm -rf ckati *.o *.d $(KATI_CXX_TEST_EXES) version.cc
+	rm -rf $(KATI_INTERMEDIATES_PATH)/ckati
+	rm -rf $(KATI_INTERMEDIATES_PATH)/*.o
+	rm -rf $(KATI_INTERMEDIATES_PATH)/*.d
+	rm -rf $(KATI_INTERMEDIATES_PATH)/version.cc
+	rm -rf $(KATI_CXX_TEST_EXES)
 
 .PHONY: ckati_clean
 
--include *.d
+-include $(KATI_INTERMEDIATES_PATH)/*.d

--- a/Makefile.ckati
+++ b/Makefile.ckati
@@ -1,0 +1,73 @@
+# Copyright 2015 Google Inc. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+CXX_SRCS:= \
+	ast.cc \
+	command.cc \
+	dep.cc \
+	eval.cc \
+	exec.cc \
+	file.cc \
+	file_cache.cc \
+	fileutil.cc \
+	find.cc \
+	flags.cc \
+	func.cc \
+	log.cc \
+	main.cc \
+	ninja.cc \
+	parser.cc \
+	rule.cc \
+	stats.cc \
+	string_piece.cc \
+	stringprintf.cc \
+	strutil.cc \
+	symtab.cc \
+	timeutil.cc \
+	value.cc \
+	var.cc \
+	version.cc
+CXX_TEST_SRCS:= \
+	$(wildcard *_test.cc)
+CXX_OBJS:=$(CXX_SRCS:.cc=.o)
+CXX_TEST_OBJS:=$(CXX_TEST_SRCS:.cc=.o)
+CXX_ALL_OBJS:=$(CXX_SRCS:.cc=.o) $(CXX_TEST_SRCS:.cc=.o)
+CXX_TEST_EXES:=$(CXX_TEST_OBJS:.o=)
+CXXFLAGS:=-g -W -Wall -MMD
+CXXFLAGS+=-O -DNOLOG
+#CXXFLAGS+=-pg
+
+ckati: $(CXX_OBJS)
+	$(CXX) -std=c++11 $(CXXFLAGS) -o $@ $(CXX_OBJS)
+
+$(CXX_ALL_OBJS): %.o: %.cc
+	$(CXX) -c -std=c++11 $(CXXFLAGS) -o $@ $<
+
+ckati_tests: $(CXX_TEST_EXES)
+
+$(CXX_TEST_EXES): $(filter-out main.o,$(CXX_OBJS))
+$(CXX_TEST_EXES): %: %.o
+	$(CXX) $^ -o $@
+
+version.cc: .git/HEAD .git/index
+	echo '// +build ignore' > $@
+	echo >> $@
+	echo 'const char* kGitVersion = "$(shell git rev-parse HEAD)";' >> $@
+
+ckati_clean:
+	rm -rf ckati *.o *.d $(CXX_TEST_EXES) version.cc
+
+.PHONY: ckati_clean
+
+-include *.d

--- a/Makefile.ckati
+++ b/Makefile.ckati
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-CXX_SRCS:= \
+KATI_CXX ?= $(CXX)
+
+KATI_CXX_SRCS:= \
 	ast.cc \
 	command.cc \
 	dep.cc \
@@ -38,27 +40,27 @@ CXX_SRCS:= \
 	value.cc \
 	var.cc \
 	version.cc
-CXX_TEST_SRCS:= \
+KATI_CXX_TEST_SRCS:= \
 	$(wildcard *_test.cc)
-CXX_OBJS:=$(CXX_SRCS:.cc=.o)
-CXX_TEST_OBJS:=$(CXX_TEST_SRCS:.cc=.o)
-CXX_ALL_OBJS:=$(CXX_SRCS:.cc=.o) $(CXX_TEST_SRCS:.cc=.o)
-CXX_TEST_EXES:=$(CXX_TEST_OBJS:.o=)
-CXXFLAGS:=-g -W -Wall -MMD
-CXXFLAGS+=-O -DNOLOG
-#CXXFLAGS+=-pg
+KATI_CXX_OBJS:=$(KATI_CXX_SRCS:.cc=.o)
+KATI_CXX_TEST_OBJS:=$(KATI_CXX_TEST_SRCS:.cc=.o)
+KATI_CXX_ALL_OBJS:=$(KATI_CXX_SRCS:.cc=.o) $(KATI_CXX_TEST_SRCS:.cc=.o)
+KATI_CXX_TEST_EXES:=$(KATI_CXX_TEST_OBJS:.o=)
+KATI_CXXFLAGS:=-g -W -Wall -MMD
+KATI_CXXFLAGS+=-O -DNOLOG
+#KATI_CXXFLAGS+=-pg
 
-ckati: $(CXX_OBJS)
-	$(CXX) -std=c++11 $(CXXFLAGS) -o $@ $(CXX_OBJS)
+ckati: $(KATI_CXX_OBJS)
+	$(KATI_CXX) -std=c++11 $(KATI_CXXFLAGS) -o $@ $(KATI_CXX_OBJS)
 
-$(CXX_ALL_OBJS): %.o: %.cc
-	$(CXX) -c -std=c++11 $(CXXFLAGS) -o $@ $<
+$(KATI_CXX_ALL_OBJS): %.o: %.cc
+	$(KATI_CXX) -c -std=c++11 $(KATI_CXXFLAGS) -o $@ $<
 
-ckati_tests: $(CXX_TEST_EXES)
+ckati_tests: $(KATI_CXX_TEST_EXES)
 
-$(CXX_TEST_EXES): $(filter-out main.o,$(CXX_OBJS))
-$(CXX_TEST_EXES): %: %.o
-	$(CXX) $^ -o $@
+$(KATI_CXX_TEST_EXES): $(filter-out main.o,$(KATI_CXX_OBJS))
+$(KATI_CXX_TEST_EXES): %: %.o
+	$(KATI_CXX) $^ -o $@
 
 version.cc: .git/HEAD .git/index
 	echo '// +build ignore' > $@
@@ -66,7 +68,7 @@ version.cc: .git/HEAD .git/index
 	echo 'const char* kGitVersion = "$(shell git rev-parse HEAD)";' >> $@
 
 ckati_clean:
-	rm -rf ckati *.o *.d $(CXX_TEST_EXES) version.cc
+	rm -rf ckati *.o *.d $(KATI_CXX_TEST_EXES) version.cc
 
 .PHONY: ckati_clean
 

--- a/Makefile.kati
+++ b/Makefile.kati
@@ -12,14 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-all: kati ckati ckati_tests
+GO_SRCS:=$(wildcard *.go)
 
-include Makefile.kati
-include Makefile.ckati
+kati: go_src_stamp
+	GOPATH=$$(pwd)/out:$${GOPATH} go install -ldflags "-X github.com/google/kati.gitVersion $(shell git rev-parse HEAD)" github.com/google/kati/cmd/kati
+	cp out/bin/kati $@
 
-test: all ckati_test go_test
-	ruby runtest.rb
+go_src_stamp: $(GO_SRCS) cmd/*/*.go
+	-rm -rf out/src/github.com/google/kati
+	mkdir -p out/src/github.com/google/kati
+	cp -a $(GO_SRCS) cmd out/src/github.com/google/kati
+	GOPATH=$$(pwd)/out:$${GOPATH} go get github.com/google/kati/cmd/kati
+	touch $@
 
-clean: ckati_clean go_clean
+go_test: $(GO_SRCS)
+	GOPATH=$$(pwd)/out:$${GOPATH} go test *.go
 
-.PHONY: test clean ckati_tests
+go_clean:
+	rm -rf out kati go_src_stamp
+
+.PHONY: go_clean go_test


### PR DESCRIPTION
This set of patches allows embedding kati inside an Android build, by putting the following snippet somewhere after include $(BUILD_SYSTEM)/config.mk:

    KATI_CXX := $(CLANG_CXX)
    KATI_INTERMEDIATES_PATH := $(HOST_OUT_INTERMEDIATES)/EXECUTABLES/ckati_intermediates
    KATI_BIN_PATH := $(HOST_OUT_EXECUTABLES)
    include $(BUILD_SYSTEM)/kati/Makefile.ckati
