### PR TITLE
Fix warnings reported by clang

### DIFF
--- a/stringprintf.cc
+++ b/stringprintf.cc
@@ -35,4 +35,5 @@ string StringPrintf(const char* format, ...) {
     str.resize(ret + 1);
   }
   assert(false);
+  __builtin_unreachable();
 }

--- a/value.cc
+++ b/value.cc
@@ -44,7 +44,7 @@ Value::~Value() {
 }
 
 string Value::DebugString() const {
-  if (this) {
+  if (static_cast<const Value*>(this)) {
     return NoLineBreak(DebugString_());
   }
   return "(null)";


### PR DESCRIPTION
stringprintf.cc:38:1: warning: control may reach end of non-void function [-Wreturn-type]

Add __builtin_unreachable(), but leave assert(false) to still get an
abort if compiled with assertions enabled.

value.cc:47:7: warning: 'this' pointer cannot be null in well-defined C++ code; pointer may be assumed to always convert to true [-Wundefined-bool-conversion]

While this _should_ never be null, DebugString() is useful to debug
cases where an Value pointer is accidentally null.  Keep the existing
behavior by casting the non-null 'this' pointer to a const Value*.