### PR TITLE
[C++] Don't sort find/ls results

### DIFF
--- a/testcase/find_command.mk
+++ b/testcase/find_command.mk
@@ -1,6 +1,8 @@
-# TODO(ninja): This test is only for ckati. ninja: fix $(sort $(shell $(1)))
+# TODO(ninja): This test is only for ckati. ninja: multiple problems
 # go: implement generic builtin find
-# ninja: $(sort $(shell "find -name testdir")) becomes "$( -name find testdir)"
+# ninja: find . finds ninja temporary files
+# ninja: escaping ! doesn't seem to be working
+# ninja: stderr gets reordered
 
 ifeq ($(shell uname),Darwin)
 USE_GNU_FIND:=
@@ -10,7 +12,7 @@ endif
 
 define run_find
 @echo $$ '$(strip $(1))'
-@echo $(sort $(shell $(1)))
+@echo $(shell $(1))
 endef
 
 test1:

--- a/testcase/find_command_sorted.mk
+++ b/testcase/find_command_sorted.mk
@@ -1,0 +1,11 @@
+# TODO(ninja): This test is only for ckati. ninja: fix $(sort $(shell $(1)))
+# go: implement generic builtin find
+# ninja: $(sort $(shell "find .")) becomes "$( .) find"
+
+define run_find
+@echo $$ '$(strip $(1))'
+@echo $(sort $(shell $(1)))
+endef
+
+test1:
+	$(call run_find, find .)


### PR DESCRIPTION
These should only be sorted if explicitly requested, otherwise
make-built binaries may be different from kati-built binaries.

This resolves some binary-diff issues for Android between libc.a built
with make vs kati/ninja. To be the same across multiple
checkouts/machines, we should probably switch android to sorting these
results, but then the kati ninja support will stop working.