### PR TITLE
[C++] Fix automatic variables in nested $(call

### DIFF
--- a/testcase/nested_call.mk
+++ b/testcase/nested_call.mk
@@ -1,0 +1,17 @@
+define inner
+{$(1)|$(origin 1),$(2)|$(origin 2)}
+endef
+
+define macro
+$(call inner,$(1)) \
+$(call inner,test2) \
+$(call inner,test3,) \
+$(call inner,test4,macro) \
+$(call inner)
+endef
+
+2=global
+
+test:
+	@echo "$(call macro,test1)"
+	@echo "$(call macro)"


### PR DESCRIPTION
An omitted argument should be blank, even if it's nested inside another
call statement that did have that argument passed.

Android uses missing arguments as defaults in many places.