### PR TITLE
Fix line continuations in multiline variables

### DIFF
--- a/testcase/multiline_define.mk
+++ b/testcase/multiline_define.mk
@@ -12,6 +12,28 @@ define or3
 $(or  ,  ,  ,)
 endef
 
+define var
+A\
+
+B
+endef
+
+define var2
+A\
+\
+
+B
+endef
+
+define var3
+A\
+B
+endef
+
+$(info $(var))
+$(info $(var2))
+$(info $(var3))
+
 test:
 	echo $(if $(call or1),FAIL,PASS)_or1
 	echo $(if $(call or2),FAIL,PASS)_or2

--- a/value.cc
+++ b/value.cc
@@ -511,9 +511,15 @@ Value* ParseExprImpl(const Loc& loc,
           r->AddValue(new Literal(TrimRightSpace(s.substr(b, i-b))));
         }
         r->AddValue(new Literal(StringPiece(" ")));
-        for (i++; i < s.size(); i++) {
-          if (!isspace(s[i]) &&
-              (s[i] != '\\' || (s.get(i+1) != '\r' && s.get(i+1) != '\n'))) {
+        // Skip the current escaped newline
+        i += 2;
+        // Then continue skipping escaped newlines, spaces, and tabs
+        for (; i < s.size(); i++) {
+          if (s[i] == '\\' && (s.get(i+1) == '\r' || s.get(i+1) == '\n')) {
+            i++;
+            continue;
+          }
+          if (s[i] != ' ' && s[i] != '\t') {
             break;
           }
         }


### PR DESCRIPTION
We were improperly merging whitespace when parsing line continuations.
The next newline should not be part of the line.

Change-Id: I3cbe776e093207b8803c6cd495598d3139cf6914