### PR TITLE
Some simple fixes

### DIFF
--- a/exec.cc
+++ b/exec.cc
@@ -98,6 +98,7 @@ class Executor {
     vector<Command*> commands;
     ce_.Eval(n, &commands);
     for (Command* command : commands) {
+      num_commands_ += 1;
       if (command->echo) {
         printf("%s\n", command->cmd.c_str());
         fflush(stdout);
@@ -126,10 +127,15 @@ class Executor {
     return output_ts;
   }
 
+  uint64_t Count() {
+    return num_commands_;
+  }
+
  private:
   CommandEvaluator ce_;
   unordered_map<Symbol, double> done_;
   string shell_;
+  uint64_t num_commands_;
 };
 
 }  // namespace
@@ -138,5 +144,10 @@ void Exec(const vector<DepNode*>& roots, Evaluator* ev) {
   unique_ptr<Executor> executor(new Executor(ev));
   for (DepNode* root : roots) {
     executor->ExecNode(root, NULL);
+  }
+  if (executor->Count() == 0) {
+    for (DepNode* root : roots) {
+      printf("kati: Nothing to be done for `%s'.\n", root->output.c_str());
+    }
   }
 }

--- a/func.cc
+++ b/func.cc
@@ -622,7 +622,7 @@ void FlavorFunc(const vector<Value*>& args, Evaluator* ev, string* s) {
 void InfoFunc(const vector<Value*>& args, Evaluator* ev, string*) {
   const string&& a = args[0]->Eval(ev);
   if (ev->avoid_io()) {
-    ev->add_delayed_output_command(StringPrintf("echo '%s'", a.c_str()));
+    ev->add_delayed_output_command(StringPrintf("echo -e \"%s\"", EchoEscape(a).c_str()));
     return;
   }
   printf("%s\n", a.c_str());
@@ -633,7 +633,7 @@ void WarningFunc(const vector<Value*>& args, Evaluator* ev, string*) {
   const string&& a = args[0]->Eval(ev);
   if (ev->avoid_io()) {
     ev->add_delayed_output_command(
-        StringPrintf("echo '%s:%d: %s' 2>&1", LOCF(ev->loc()), a.c_str()));
+        StringPrintf("echo -e \"%s:%d: %s\" 2>&1", LOCF(ev->loc()), EchoEscape(a).c_str()));
     return;
   }
   printf("%s:%d: %s\n", LOCF(ev->loc()), a.c_str());
@@ -644,8 +644,8 @@ void ErrorFunc(const vector<Value*>& args, Evaluator* ev, string*) {
   const string&& a = args[0]->Eval(ev);
   if (ev->avoid_io()) {
     ev->add_delayed_output_command(
-        StringPrintf("echo '%s:%d: *** %s.' 2>&1 && false",
-                     LOCF(ev->loc()), a.c_str()));
+        StringPrintf("echo -e \"%s:%d: *** %s.\" 2>&1 && false",
+                     LOCF(ev->loc()), EchoEscape(a).c_str()));
     return;
   }
   ev->Error(StringPrintf("*** %s.", a.c_str()));

--- a/ninja.cc
+++ b/ninja.cc
@@ -271,6 +271,10 @@ class NinjaGenerator {
       prev_char = *in;
     }
 
+    if (prev_backslash) {
+      cmd_buf->resize(cmd_buf->size()-1);
+    }
+
     while (true) {
       char c = (*cmd_buf)[cmd_buf->size()-1];
       if (!isspace(c) && c != ';')

--- a/ninja.cc
+++ b/ninja.cc
@@ -526,6 +526,9 @@ class NinjaGenerator {
             EscapeBuildTarget(node->output).c_str(),
             rule_name.c_str());
     vector<Symbol> order_onlys;
+    if (node->is_phony) {
+      fprintf(fp_, " _kati_always_build_");
+    }
     for (DepNode* d : node->deps) {
       fprintf(fp_, " %s", EscapeBuildTarget(d->output).c_str());
     }
@@ -608,6 +611,8 @@ class NinjaGenerator {
 
     fprintf(fp_, "pool local_pool\n");
     fprintf(fp_, " depth = %d\n\n", g_num_jobs);
+
+    fprintf(fp_, "build _kati_always_build_: phony\n\n");
 
     EmitRegenRules(orig_args);
 

--- a/ninja.cc
+++ b/ninja.cc
@@ -414,12 +414,8 @@ class NinjaGenerator {
     if (g_detect_android_echo && node->output.str() == "out")
       return;
 
-    // Removing this will fix auto_vars.mk, build_once.mk, and
-    // command_vars.mk. However, this change will make
-    // ninja_normalized_path2.mk fail and cause a lot of warnings for
-    // Android build.
-    if (node->cmds.empty() &&
-        node->deps.empty() && node->order_onlys.empty() && !node->is_phony) {
+    // This node is a leaf node
+    if (!node->has_rule && !node->is_phony) {
       return;
     }
 

--- a/runtest.rb
+++ b/runtest.rb
@@ -170,11 +170,6 @@ run_make_test = proc do |mk|
   end
 
   run_in_testdir(mk) do |name|
-    # TODO: Fix
-    if name =~ /eval_assign/ && ckati
-      next
-    end
-
     File.open("Makefile", 'w') do |ofile|
       ofile.print(c)
     end

--- a/strutil.cc
+++ b/strutil.cc
@@ -427,3 +427,24 @@ string ConcatDir(StringPiece b, StringPiece n) {
   NormalizePath(&r);
   return r;
 }
+
+string EchoEscape(const string str) {
+  const char *in = str.c_str();
+  string buf;
+  for (; *in; in++) {
+    switch(*in) {
+      case '\\':
+        buf += "\\\\\\\\";
+        break;
+      case '\n':
+        buf += "\\n";
+        break;
+      case '"':
+        buf += "\\\"";
+        break;
+      default:
+        buf += *in;
+    }
+  }
+  return buf;
+}

--- a/strutil.h
+++ b/strutil.h
@@ -138,4 +138,6 @@ string SortWordsInString(StringPiece s);
 
 string ConcatDir(StringPiece b, StringPiece n);
 
+string EchoEscape(const string str);
+
 #endif  // STRUTIL_H_

--- a/testcase/auto_vars.mk
+++ b/testcase/auto_vars.mk
@@ -1,5 +1,3 @@
-# TODO(c-ninja): Fix
-
 test1: foo bar foo
 	echo $<
 	echo $@

--- a/testcase/build_once.mk
+++ b/testcase/build_once.mk
@@ -1,5 +1,3 @@
-# TODO(c-ninja): Fix
-
 # expect protoc compile/link only once.
 test: foo
 

--- a/testcase/command_vars.mk
+++ b/testcase/command_vars.mk
@@ -1,5 +1,3 @@
-# TODO(c-ninja): Fix - should emit phony rule for bar baz
-
 test: foo
 
 foo: bar baz

--- a/testcase/escaped_backslash.mk
+++ b/testcase/escaped_backslash.mk
@@ -6,3 +6,7 @@ test:
 	echo $(two_backslash)
 	echo \\
 	echo \\ foo
+	$(info echo $(no_comment))
+	$(info echo $(two_backslash))
+	$(info echo \\)
+	$(info echo \\ foo)

--- a/testcase/multiline_arg.mk
+++ b/testcase/multiline_arg.mk
@@ -1,5 +1,3 @@
-# TODO(c-ninja): Fix - "echo \" should be "echo ".
-
 SHELL:=/bin/bash
 
 define func

--- a/testcase/multiline_define.mk
+++ b/testcase/multiline_define.mk
@@ -30,11 +30,10 @@ A\
 B
 endef
 
-$(info $(var))
-$(info $(var2))
-$(info $(var3))
-
 test:
 	echo $(if $(call or1),FAIL,PASS)_or1
 	echo $(if $(call or2),FAIL,PASS)_or2
 	echo $(if $(call or3),FAIL,PASS)_or3
+	$(info $(var))
+	$(info $(var2))
+	$(info $(var3))

--- a/testcase/ninja_normalized_path2.mk
+++ b/testcase/ninja_normalized_path2.mk
@@ -1,12 +1,15 @@
-# Unlike ninja_normalized_path.mk, this passes with the current
-# implementation because we remove a/./b. See EmitNode in ninja.cc.
+# Ninja only supports duplicated targets for pure dependencies.
+# These will both be mapped to the same target. Two rules like
+# this should cause an warning (and really should cause an warning
+# in make too -- this can be very confusing, and can be racy)
+ifneq ($(MAKE),kati)
+$(info ninja: warning: multiple rules generate a/b.)
+endif
 
-test1:
-	mkdir a
-
-test2: a/b a/./b
+test: a/b a/./b
 
 a/b:
+	mkdir -p $(dir $@)
 	echo $@
 
 a/./b:

--- a/testcase/nothing_to_do.mk
+++ b/testcase/nothing_to_do.mk
@@ -1,3 +1,3 @@
-# TODO(c): Show something like "nothing to be done"
+# TODO(c-ninja): Fix. See EmitNode in ninja.cc
 
 Makefile:

--- a/testcase/nothing_to_do.mk
+++ b/testcase/nothing_to_do.mk
@@ -1,3 +1,1 @@
-# TODO(c-ninja): Fix. See EmitNode in ninja.cc
-
 Makefile:

--- a/testcase/phony.mk
+++ b/testcase/phony.mk
@@ -1,5 +1,3 @@
-# TODO(ninja): Fix - ninja emits "no work to do" in test4
-
 .PHONY: foo
 	echo PASS phony foo
 .PHONY: bar

--- a/testcase/warning.mk
+++ b/testcase/warning.mk
@@ -1,5 +1,12 @@
 $(warning foo)
 
+define baz
+b
+a
+z
+endef
+
 test:
-	$(warning bar)
+	$(warning bar'""')
+	$(warning $(baz))
 	echo PASS


### PR DESCRIPTION
A few ninja tests fixes for multiline and special character escaping -- multiline_arg, multiline_define, escaped_backslash.mk. And one to fix all of the empty rules not being emitted.

A ckati fix for nothing_to_do

And then some fixes for phony rules:
* Don't build all phony rules when running without ninja
* Always re-run phony rules even if the file exists with ninja