### PR TITLE
Fix error reading .kati_stamp when wildcard matches have changed

### DIFF
--- a/ninja.cc
+++ b/ninja.cc
@@ -962,9 +962,9 @@ bool NeedsRegen(const char* ninja_suffix,
       Glob(pat.c_str(), &files);
       sort(files->begin(), files->end());
       bool needs_regen = files->size() != static_cast<size_t>(num_files);
-      if (!needs_regen) {
-        for (int j = 0; j < num_files; j++) {
-          LOAD_STRING(fp, &s);
+      for (int j = 0; j < num_files; j++) {
+        LOAD_STRING(fp, &s);
+        if (!needs_regen) {
           if ((*files)[j] != s) {
             needs_regen = true;
             break;


### PR DESCRIPTION
NeedsRegen re-matches all the wildcards that were executed when
the ninja file was first generated.  If the number of matches
is different, it was skipping LOAD_STRING for the match list
completely, leaving the file position incorrect for reading
the next glob pattern.  If the glob pattern matches the pattern
passed to --ignore_dirty NeedsRegen will continue to the next
glob pattern and think the file format is incorrect.

Always call LOAD_STRING num_files times, and move the check
for matching files only if needs_regen is not set inside the
loop.

Change-Id: I7f6cf2eb7a5f802a62c5bc8a915725bc4d3475c6