### PR TITLE
Support building out of a non-git directory

### DIFF
--- a/Makefile.ckati
+++ b/Makefile.ckati
@@ -95,12 +95,19 @@ $(KATI_CXX_TEST_EXES): $(KATI_BIN_PATH)/%: $(KATI_INTERMEDIATES_PATH)/%.o
 	$(KATI_LD) $^ -o $@ $(KATI_LIBS)
 
 # Rule to generate version.cc
-KATI_GIT_DIR := $(shell cd $(KATI_SRC_PATH) && git rev-parse --show-toplevel)
-$(KATI_INTERMEDIATES_PATH)/version.cc: $(KATI_GIT_DIR)/.git/HEAD $(KATI_GIT_DIR)/.git/index
+KATI_GIT_DIR := $(shell git -C $(KATI_SRC_PATH) rev-parse --show-toplevel)
+ifneq ($(KATI_GIT_DIR),)
+KATI_VERSION_DEPS := $(KATI_GIT_DIR)/.git/HEAD $(KATI_GIT_DIR)/.git/index
+KATI_VERSION := $(shell git -C $(KATI_GIT_DIR) rev-parse HEAD)
+else
+KATI_VERSION_DEPS :=
+KATI_VERSION := unknown
+endif
+$(KATI_INTERMEDIATES_PATH)/version.cc: $(KATI_VERSION_DEPS)
 	@mkdir -p $(dir $@)
 	echo '// +build ignore' > $@
 	echo >> $@
-	echo 'const char* kGitVersion = "$(shell git rev-parse HEAD)";' >> $@
+	echo 'const char* kGitVersion = "$(KATI_VERSION)";' >> $@
 
 ckati_clean:
 	rm -rf $(KATI_INTERMEDIATES_PATH)/ckati


### PR DESCRIPTION
Don't assume that kati is in a valid git directory.

Change-Id: I026fa07880924442f23fa4b1b8f40937fbd1afb8