### PR TITLE
Add support for default targets in ninja output

### DIFF
--- a/dep.cc
+++ b/dep.cc
@@ -104,6 +104,7 @@ DepNode::DepNode(Symbol o, bool p)
     : output(o),
       has_rule(false),
       is_phony(p),
+      is_default_target(false),
       rule_vars(NULL),
       output_pattern(Symbol::IsUninitialized()) {
   g_dep_node_pool->push_back(this);
@@ -137,12 +138,14 @@ class DepBuilder {
 
   void Build(vector<Symbol> targets,
              vector<DepNode*>* nodes) {
-    if (targets.empty()) {
-      if (!first_rule_) {
-        ERROR("*** No targets.");
-      }
-      CHECK(!first_rule_->outputs.empty());
+    if (!first_rule_) {
+      ERROR("*** No targets.");
+    }
+    CHECK(!first_rule_->outputs.empty());
 
+    first_rule_->is_default_target = true;
+
+    if (targets.empty()) {
       targets.push_back(first_rule_->outputs[0]);
     }
     if (g_flags.gen_all_phony_targets) {
@@ -505,6 +508,7 @@ class DepBuilder {
 
     n->has_rule = true;
     n->cmds = rule->cmds;
+    n->is_default_target = rule->is_default_target;
     if (cur_rule_vars_->empty()) {
       n->rule_vars = NULL;
     } else {

--- a/dep.h
+++ b/dep.h
@@ -39,6 +39,7 @@ struct DepNode {
   vector<DepNode*> parents;
   bool has_rule;
   bool is_phony;
+  bool is_default_target;
   vector<Symbol> actual_inputs;
   Vars* rule_vars;
   Symbol output_pattern;

--- a/ninja.cc
+++ b/ninja.cc
@@ -438,9 +438,7 @@ class NinjaGenerator {
       }
     }
 
-    EmitBuild(node, rule_name);
-    if (use_local_pool)
-      fprintf(fp_, " pool = local_pool\n");
+    EmitBuild(node, rule_name, use_local_pool);
 
     for (DepNode* d : node->deps) {
       EmitNode(d);
@@ -499,9 +497,10 @@ class NinjaGenerator {
     s->swap(r);
   }
 
-  void EmitBuild(DepNode* node, const string& rule_name) {
+  void EmitBuild(DepNode* node, const string& rule_name, bool use_local_pool) {
+    string target = EscapeBuildTarget(node->output);
     fprintf(fp_, "build %s: %s",
-            EscapeBuildTarget(node->output).c_str(),
+            target.c_str(),
             rule_name.c_str());
     vector<Symbol> order_onlys;
     if (node->is_phony) {
@@ -517,6 +516,11 @@ class NinjaGenerator {
       }
     }
     fprintf(fp_, "\n");
+    if (use_local_pool)
+      fprintf(fp_, " pool = local_pool\n");
+    if (node->is_default_target) {
+      fprintf(fp_, "default %s\n", target.c_str());
+    }
   }
 
   void EmitRegenRules(const string& orig_args) {

--- a/rule.cc
+++ b/rule.cc
@@ -50,7 +50,8 @@ bool IsPatternRule(StringPiece s) {
 Rule::Rule()
     : is_double_colon(false),
       is_suffix_rule(false),
-      cmd_lineno(0) {
+      cmd_lineno(0),
+      is_default_target(false) {
 }
 
 void ParseRule(Loc& loc, StringPiece line, char term,

--- a/rule.h
+++ b/rule.h
@@ -44,6 +44,7 @@ class Rule {
   vector<Value*> cmds;
   Loc loc;
   int cmd_lineno;
+  bool is_default_target;
 
  private:
   void Error(const string& msg) {

--- a/testcase/default_rule.mk
+++ b/testcase/default_rule.mk
@@ -1,0 +1,5 @@
+abc:
+	echo PASS
+
+def:
+	echo FAIL


### PR DESCRIPTION
make treats the first target it sees as the default target if no goals
are passed on the commmand line.  When generating a ninja file, mark
this target with "default" to make it build if no goals are passed to
ninja.

Change-Id: I11befa4f88b8ca8734fdc7dd470c2a0a3722410d