### PR TITLE
Use ordered containers to prevent changes to ninja files

### DIFF
--- a/dep.cc
+++ b/dep.cc
@@ -18,7 +18,9 @@
 
 #include <algorithm>
 #include <iterator>
+#include <map>
 #include <memory>
+#include <set>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -524,7 +526,7 @@ class DepBuilder {
   }
 
   Evaluator* ev_;
-  unordered_map<Symbol, shared_ptr<Rule>> rules_;
+  map<Symbol, shared_ptr<Rule>> rules_;
   const unordered_map<Symbol, Vars*>& rule_vars_;
   unique_ptr<Vars> cur_rule_vars_;
 
@@ -534,7 +536,7 @@ class DepBuilder {
 
   shared_ptr<Rule> first_rule_;
   unordered_map<Symbol, DepNode*> done_;
-  unordered_set<Symbol> phony_;
+  set<Symbol> phony_;
 };
 
 void MakeDep(Evaluator* ev,

--- a/symtab.h
+++ b/symtab.h
@@ -66,6 +66,10 @@ inline bool operator==(const Symbol& x, const Symbol& y) {
   return x.val() == y.val();
 }
 
+inline bool operator<(const Symbol& x, const Symbol& y) {
+  return x.str() < y.str();
+}
+
 namespace std {
 template<> struct hash<Symbol> {
   size_t operator()(const Symbol& s) const {


### PR DESCRIPTION
When using --gen_all_targets / --gen_all_phony_targets, we're changing
the selected targets using unordered containers. This causes trivial
changes to the makefiles to trigger large changes to the generated ninja
files. Switch to using ordered containers so that the order is the same
every time.