### PR TITLE
Fix ninja tests if NINJA_STATUS is set

### DIFF
--- a/runtest.rb
+++ b/runtest.rb
@@ -27,6 +27,7 @@ while true
   elsif ARGV[0] == '-n'
     via_ninja = true
     ARGV.shift
+    ENV['NINJA_STATUS'] = 'NINJACMD: '
   elsif ARGV[0] == '-v'
     show_failing = true
     ARGV.shift
@@ -93,7 +94,7 @@ def run_in_testdir(test_filename)
 end
 
 def normalize_ninja_log(log, mk)
-  log.gsub!(/^\[\d+\/\d+\] .*\n/, '')
+  log.gsub!(/^NINJACMD: .*\n/, '')
   log.gsub!(/^ninja: no work to do\.\n/, '')
   log.gsub!(/^ninja: error: (.*, needed by .*),.*/,
             '*** No rule to make target \\1.')


### PR DESCRIPTION
If NINJA_STATUS is set in the environment when running runtest.rb -c -n
the regexp to match ninja status lines may not match, causing all the
tests to fail.  Set NINJA_STATUS to a known value that is easy to match
for.

Change-Id: Ice892341a252ca305f770d5c92d9716ee857156b