### PR TITLE
Add --no_ignore_dirty flag

### DIFF
--- a/flags.cc
+++ b/flags.cc
@@ -110,6 +110,9 @@ void Flags::Parse(int argc, char** argv) {
     } else if (ParseCommandLineOptionWithArg(
         "--ignore_dirty",
         argv, &i, &ignore_dirty_pattern)) {
+    } else if (ParseCommandLineOptionWithArg(
+        "--no_ignore_dirty",
+        argv, &i, &no_ignore_dirty_pattern)) {
     } else if (arg[0] == '-') {
       ERROR("Unknown flag: %s", arg);
     } else {

--- a/flags.h
+++ b/flags.h
@@ -38,6 +38,7 @@ struct Flags {
   bool use_find_emulator;
   const char* goma_dir;
   const char* ignore_dirty_pattern;
+  const char* no_ignore_dirty_pattern;
   const char* ignore_optional_include_pattern;
   const char* makefile;
   const char* ninja_dir;

--- a/func.cc
+++ b/func.cc
@@ -523,13 +523,15 @@ static vector<CommandResult*> g_command_results;
 bool ShouldStoreCommandResult(StringPiece cmd) {
   if (HasWord(cmd, "date") || HasWord(cmd, "echo"))
     return false;
-  if (g_flags.ignore_dirty_pattern) {
-    Pattern pat(g_flags.ignore_dirty_pattern);
-    for (StringPiece tok : WordScanner(cmd)) {
-      if (pat.Match(tok))
-        return false;
+
+  Pattern pat(g_flags.ignore_dirty_pattern);
+  Pattern nopat(g_flags.no_ignore_dirty_pattern);
+  for (StringPiece tok : WordScanner(cmd)) {
+    if (pat.Match(tok) && !nopat.Match(tok)) {
+      return false;
     }
   }
+
   return true;
 }
 

--- a/ninja.cc
+++ b/ninja.cc
@@ -765,8 +765,9 @@ void GenerateNinja(const vector<DepNode*>& nodes,
 }
 
 static bool ShouldIgnoreDirty(StringPiece s) {
-  return (g_flags.ignore_dirty_pattern &&
-          Pattern(g_flags.ignore_dirty_pattern).Match(s));
+  Pattern pat(g_flags.ignore_dirty_pattern);
+  Pattern nopat(g_flags.no_ignore_dirty_pattern);
+  return pat.Match(s) && !nopat.Match(s);
 }
 
 bool NeedsRegen(double start_time, const string& orig_args) {


### PR DESCRIPTION
Android needs to ignore dirty files under out/ when deciding to rebuild,
except for the soong-generated out/Android.mk.  Add a --no_ignore_dirty
flag to override the pattern provided in --ignore_dirty.

Change-Id: I8810963f4dff07b51187868c7afedb10c6a4cb2e