### PR TITLE
Allow building Kati with Soong for Android

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -1,0 +1,77 @@
+// Copyright 2016 Google Inc. All rights reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+cc_library_host_static {
+    name: "libckati",
+    srcs: [
+        "command.cc",
+        "dep.cc",
+        "eval.cc",
+        "exec.cc",
+        "expr.cc",
+        "file.cc",
+        "file_cache.cc",
+        "fileutil.cc",
+        "find.cc",
+        "flags.cc",
+        "func.cc",
+        "io.cc",
+        "log.cc",
+        "ninja.cc",
+        "parser.cc",
+        "rule.cc",
+        "stats.cc",
+        "stmt.cc",
+        "string_piece.cc",
+        "stringprintf.cc",
+        "strutil.cc",
+        "symtab.cc",
+        "timeutil.cc",
+        "var.cc",
+        "version_unknown.cc",
+    ],
+    cflags: ["-W", "-Wall", "-DNOLOG"],
+}
+
+cc_binary_host {
+    name: "ckati",
+    srcs: [
+        "main.cc",
+    ],
+    whole_static_libs: ["libckati"],
+    cflags: ["-W", "-Wall", "-DNOLOG"],
+    target: {
+        linux: {
+            host_ldlibs: ["-lrt"],
+        },
+    },
+}
+
+cc_test_host {
+    name: "ckati_test",
+    test_per_src: true,
+    srcs: [
+        "find_test.cc",
+        "ninja_test.cc",
+        "string_piece_test.cc",
+        "strutil_test.cc",
+    ],
+    gtest: false,
+    whole_static_libs: ["libckati"],
+    target: {
+        linux: {
+            host_ldlibs: ["-lrt"],
+        },
+    },
+}

--- a/timeutil.cc
+++ b/timeutil.cc
@@ -16,7 +16,7 @@
 
 #include "timeutil.h"
 
-#include <sys/time.h>
+#include <time.h>
 
 #include "log.h"
 

--- a/version_unknown.cc
+++ b/version_unknown.cc
@@ -1,0 +1,17 @@
+// Copyright 2016 Google Inc. All rights reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build ignore
+
+const char* kGitVersion = "unknown";


### PR DESCRIPTION
Currently, Android sets some cflags and uses make to build kati. This
still uses some of the system headers and libraries instead of the
hermetic ones in the tree. Kati and makeparallel are the two remaining
binaries being built outside of ninja.

In order to fix all of these, define an Android.bp file for Soong, then
when enabled, Android will ask Soong to build kati instead of including
Makefile.ckati.

And I'm hardcoding the version to unknown for now, Soong's genrule is
not yet flexible enough to handle the optional dependency.