### PR TITLE
[C++] Add support for multiple filenames to findleaves emulation

### DIFF
--- a/find.cc
+++ b/find.cc
@@ -262,10 +262,11 @@ class DirentDirNode : public DirentNode {
         if (!c->RunFind(fc, d + 1, path, cur_read_dirs, out))
           return false;
         path->resize(orig_path_size);
-        // Found a leaf, stop the search.
-        if (orig_out_size != out->size())
-          return true;
       }
+
+      // Found a leaf, stop the search.
+      if (orig_out_size != out->size())
+        return true;
 
       for (const auto& p : children_) {
         DirentNode* c = p.second;
@@ -593,14 +594,30 @@ class FindCommandParser {
     fc_->type = FindCommandType::FINDLEAVES;
     fc_->follows_symlinks = true;
     StringPiece tok;
+    vector<StringPiece> findfiles;
     while (true) {
       if (!GetNextToken(&tok))
         return false;
       if (tok.empty()) {
-        if (fc_->finddirs.size() < 2)
-          return false;
-        fc_->print_cond.reset(new NameCond(fc_->finddirs.back().as_string()));
-        fc_->finddirs.pop_back();
+        if (fc_->finddirs.size() == 0) {
+          // backwards compatibility
+          if (findfiles.size() < 2)
+            return false;
+          fc_->finddirs.swap(findfiles);
+          fc_->print_cond.reset(new NameCond(fc_->finddirs.back().as_string()));
+          fc_->finddirs.pop_back();
+        } else {
+          if (findfiles.size() < 1)
+            return false;
+          for (auto& file : findfiles) {
+            FindCond* cond = new NameCond(file.as_string());
+            if (fc_->print_cond.get()) {
+              cond = new OrCond(fc_->print_cond.release(), cond);
+            }
+            CHECK(!fc_->print_cond.get());
+            fc_->print_cond.reset(cond);
+          }
+        }
         return true;
       }
 
@@ -621,11 +638,14 @@ class FindCommandParser {
           return false;
         }
         fc_->mindepth = d;
+      } else if (HasPrefix(tok, "--dir=")) {
+        StringPiece dir= tok.substr(strlen("--dir="));
+        fc_->finddirs.push_back(dir);
       } else if (HasPrefix(tok, "--")) {
         WARN("Unknown flag in findleaves.py: %.*s", SPF(tok));
         return false;
       } else {
-        fc_->finddirs.push_back(tok);
+        findfiles.push_back(tok);
       }
     }
   }


### PR DESCRIPTION
Add support for the new findleaves multiple filename searching
implemented in
https://android.googlesource.com/platform/build/+/9808645cd9800a7bf7afeb208f3f25c208c64c20:

Add support for a new --dir= option to specify one or more directories
to search, and then treat any remaining options as filenames.  If no
directories are specified, fall back to treating only the last option as
a filename and the rest as directories.

Change-Id: Ibbc81cd65bd63901ae1d0ca99ffc6255c5344d98