### PR TITLE
[C++] $(eval) stops when first character is '#'

### DIFF
--- a/func.cc
+++ b/func.cc
@@ -458,10 +458,6 @@ void EvalFunc(const vector<Value*>& args, Evaluator* ev, string*) {
   //const string text = args[0]->Eval(ev);
   string* text = new string;
   args[0]->Eval(ev, text);
-  if ((*text)[0] == '#') {
-    delete text;
-    return;
-  }
   if (ev->avoid_io()) {
     KATI_WARN("%s:%d: *warning*: $(eval) in a recipe is not recommended: %s",
               LOCF(ev->loc()), text->c_str());

--- a/testcase/eval_starts_with_comment.mk
+++ b/testcase/eval_starts_with_comment.mk
@@ -1,0 +1,9 @@
+.PHONY: test
+
+define _rule
+# comment
+test:
+	echo PASS
+endef
+
+$(eval $(_rule))


### PR DESCRIPTION
Regression when compared to GNU make behaviour.

Test case:

 $ cat ../Makefile.comment-in-macro
 .PHONY: all

 define _rule
 # comment
 all:
        :
 endef

 $(eval $(_rule))

 $ make -f Makefile.comment-in-macro
 :
 $ ckati --ninja --ninja_dir . --gen_all_targets -f Makefile.comment-in-macro
 *** No targets.

Fixes https://github.com/google/kati/issues/74