### PR TITLE
Allow command line variables to override file variables

### DIFF
--- a/flags.cc
+++ b/flags.cc
@@ -47,10 +47,26 @@ static bool ParseCommandLineOptionWithArg(StringPiece option,
   return false;
 }
 
+extern "C" char** environ;
+
 void Flags::Parse(int argc, char** argv) {
   subkati_args.push_back(argv[0]);
   num_jobs = num_cpus = sysconf(_SC_NPROCESSORS_ONLN);
   const char* num_jobs_str;
+
+  for (char** p = environ; *p; p++) {
+    const char* prefix = "MAKEFLAGS=";
+    if (HasPrefix(*p, prefix)) {
+      for (StringPiece tok : WordScanner(*p + strlen(prefix))) {
+        if (!HasPrefix(tok, "-")) {
+          size_t found = tok.find("=");
+          if (found != string::npos) {
+            cl_vars.push_back(tok);
+          }
+        }
+      }
+    }
+  }
 
   for (int i = 1; i < argc; i++) {
     const char* arg = argv[i];

--- a/symtab.cc
+++ b/symtab.cc
@@ -69,6 +69,10 @@ void Symbol::SetGlobalVar(Var* v, bool is_override) const {
        orig->Origin() == VarOrigin::ENVIRONMENT_OVERRIDE)) {
     return;
   }
+  if (orig->Origin() == VarOrigin::COMMAND_LINE &&
+         v->Origin() == VarOrigin::FILE) {
+    return;
+  }
   if (orig->Origin() == VarOrigin::AUTOMATIC) {
     ERROR("overriding automatic variable is not implemented yet");
   }


### PR DESCRIPTION
Test case:
$ cat Makefile
VAR := FAIL
$(info $(VAR))
all:
	@echo $(VAR)

$ ckati -f Makefile VAR=PASS
PASS
PASS