### PR TITLE
Add --regen_debug

### DIFF
--- a/flags.cc
+++ b/flags.cc
@@ -86,10 +86,13 @@ void Flags::Parse(int argc, char** argv) {
     } else if (!strcmp(arg, "--regen")) {
       // TODO: Make this default.
       regen = true;
+    } else if (!strcmp(arg, "--regen_debug")) {
+      regen_debug = true;
     } else if (!strcmp(arg, "--regen_ignoring_kati_binary")) {
       regen_ignoring_kati_binary = true;
     } else if (!strcmp(arg, "--dump_kati_stamp")) {
       dump_kati_stamp = true;
+      regen_debug = true;
     } else if (!strcmp(arg, "--detect_android_echo")) {
       detect_android_echo = true;
     } else if (!strcmp(arg, "--detect_depfiles")) {

--- a/flags.h
+++ b/flags.h
@@ -36,6 +36,7 @@ struct Flags {
   bool is_silent_mode;
   bool is_syntax_check_only;
   bool regen;
+  bool regen_debug;
   bool regen_ignoring_kati_binary;
   bool use_find_emulator;
   const char* goma_dir;

--- a/regen.cc
+++ b/regen.cc
@@ -132,7 +132,7 @@ class StampChecker {
     const string& stamp_filename = GetNinjaStampFilename();
     FILE* fp = fopen(stamp_filename.c_str(), "rb");
     if (!fp) {
-      if (g_flags.dump_kati_stamp)
+      if (g_flags.regen_debug)
         printf("%s: %s\n", stamp_filename.c_str(), strerror(errno));
       return true;
     }
@@ -145,7 +145,7 @@ class StampChecker {
       fprintf(stderr, "incomplete kati_stamp, regenerating...\n");
       RETURN_TRUE;
     }
-    if (g_flags.dump_kati_stamp)
+    if (g_flags.regen_debug)
       printf("Generated time: %f\n", gen_time);
 
     string s, s2;
@@ -163,7 +163,7 @@ class StampChecker {
           }
         }
         if (ShouldIgnoreDirty(s)) {
-          if (g_flags.dump_kati_stamp)
+          if (g_flags.regen_debug)
             printf("file %s: ignored (%f)\n", s.c_str(), ts);
           continue;
         }
@@ -325,7 +325,7 @@ class StampChecker {
 
   bool CheckShellResult(const ShellResult* sr, string* err) {
     if (!ShouldRunCommand(sr)) {
-      if (g_flags.dump_kati_stamp)
+      if (g_flags.regen_debug)
         printf("shell %s: clean (no rerun)\n", sr->cmd.c_str());
       return false;
     }
@@ -351,7 +351,7 @@ class StampChecker {
         //*err += StringPrintf("%s => %s\n", expected.c_str(), result.c_str());
       }
       return true;
-    } else if (g_flags.dump_kati_stamp) {
+    } else if (g_flags.regen_debug) {
       printf("shell %s: clean (rerun)\n", sr->cmd.c_str());
     }
     return false;


### PR DESCRIPTION
This prints information about the regen process during a normal build, including which shell commands where rerun or ignored.

My main goal is to understand if it's safe to remove our --ignore_dirty argument. So I need to understand which files were dirty, but ignored. And I'd also like to know which shell commands were run (or would be run if not ignored), to identify any that may cause side-effects (whether
desired or not).

It's different from --dump-kati-stamp, since --dump-kati-stamp stops kati before actually building anything, and continues after the first dirty indication in an attempt to find every difference.