### PR TITLE
Workaround lifetime problem identified by ASAN

### DIFF
--- a/find.h
+++ b/find.h
@@ -41,7 +41,7 @@ struct FindCommand {
   FindCommandType type;
   string chdir;
   string testdir;
-  vector<StringPiece> finddirs;
+  vector<string> finddirs;
   bool follows_symlinks;
   unique_ptr<FindCond> print_cond;
   unique_ptr<FindCond> prune_cond;


### PR DESCRIPTION
When we run ConcatDir in NinjaGenerator::GenerateStamp, we were hitting a container overflow from ASAN. When dumping the memory contents, it looked like the StringPiece's data was pointed to a corrupted piece of memory. Instead of tracking it down, just copy the strings upon creation.

This is causing kati to take a few extra seconds on master (5% increase for a build that otherwise does nothing), so this should probably be investigated.