### PR TITLE
Don't ignore all date/echo commands

### DIFF
--- a/func.cc
+++ b/func.cc
@@ -533,7 +533,9 @@ static void ShellFuncImpl(const string& shell, const string& cmd,
 static vector<CommandResult*> g_command_results;
 
 bool ShouldStoreCommandResult(StringPiece cmd) {
-  if (HasWord(cmd, "date") || HasWord(cmd, "echo"))
+  // We really just want to ignore this one, or remove BUILD_DATETIME from
+  // Android completely
+  if (cmd == "date +%s")
     return false;
 
   Pattern pat(g_flags.ignore_dirty_pattern);


### PR DESCRIPTION
echo commands may have side-effects (writing a file), or be testing a condition and echoing a different value.

date commands may be part of a larger command as well. In any case, if the command changes, and would cause changes to the ninja file, then we want to regenerate the ninja file.

Just whitelist `date +%s` for now, since Android uses that as its only build-time date source, and we don't want to rebuild the ninja file every time for that. Eventually, it should be removed, but that means removing all makefile choices on BUILD_NUMBER, since that depends on BUILD_DATETIME as well. In either case, the real value should never be inserted into the ninja file.