### PR TITLE
Support marking variables as readonly

### DIFF
--- a/eval.h
+++ b/eval.h
@@ -125,6 +125,8 @@ class Evaluator {
   bool is_posix_;
 
   static unordered_set<Symbol> used_undefined_vars_;
+
+  Symbol kati_readonly_;
 };
 
 #endif  // EVAL_H_

--- a/symtab.cc
+++ b/symtab.cc
@@ -59,11 +59,20 @@ Var* Symbol::GetGlobalVar() const {
   return v;
 }
 
-void Symbol::SetGlobalVar(Var* v, bool is_override) const {
+void Symbol::SetGlobalVar(Var* v, bool is_override, bool* readonly) const {
   if (static_cast<size_t>(v_) >= g_symbol_data.size()) {
     g_symbol_data.resize(v_ + 1);
   }
   Var* orig = g_symbol_data[v_].gv;
+  if (orig->ReadOnly()) {
+    if (readonly != nullptr)
+      *readonly = true;
+    else
+      ERROR("*** cannot assign to readonly variable: %s", c_str());
+    return;
+  } else if (readonly != nullptr) {
+    *readonly = false;
+  }
   if (!is_override &&
       (orig->Origin() == VarOrigin::OVERRIDE ||
        orig->Origin() == VarOrigin::ENVIRONMENT_OVERRIDE)) {

--- a/symtab.h
+++ b/symtab.h
@@ -56,7 +56,7 @@ class Symbol {
   bool IsValid() const { return v_ >= 0; }
 
   Var* GetGlobalVar() const;
-  void SetGlobalVar(Var* v, bool is_override = false) const;
+  void SetGlobalVar(Var* v, bool is_override = false, bool* readonly = nullptr) const;
 
  private:
   explicit Symbol(int v);

--- a/testcase/readonly_global.sh
+++ b/testcase/readonly_global.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -u
+
+mk="$@"
+
+function build() {
+  cat <<EOF > Makefile
+FOO $1 bar
+.KATI_READONLY $2 FOO
+FOO $3 baz
+all:
+EOF
+
+  echo "Testcase: $1 $2 $3"
+  if echo "${mk}" | grep -q "^make"; then
+    # Make doesn't support .KATI_READONLY
+    echo "Makefile:3: *** cannot assign to readonly variable: FOO"
+  else
+    ${mk} 2>&1 && echo "Clean exit"
+  fi
+}
+
+build "=" "=" "="
+build "=" "+=" "="
+build "=" ":=" "="
+
+build "=" ":=" ":="
+build "=" ":=" "+="
+
+build ":=" ":=" ":="
+build ":=" ":=" "+="
+build ":=" ":=" "="

--- a/testcase/readonly_global_missing.sh
+++ b/testcase/readonly_global_missing.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -u
+
+mk="$@"
+
+cat <<EOF > Makefile
+all: FOO = bar
+.KATI_READONLY = FOO
+all:
+EOF
+
+if echo "${mk}" | grep -q "^make"; then
+  # Make doesn't support .KATI_READONLY
+  echo "Makefile:2: *** unknown variable: FOO"
+else
+  ${mk} 2>&1 && echo "Clean exit"
+fi

--- a/testcase/readonly_rule.sh
+++ b/testcase/readonly_rule.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -u
+
+mk="$@"
+
+function build() {
+  cat <<EOF > Makefile
+all: FOO $1 bar
+all: .KATI_READONLY $2 FOO
+FOO $3 foo
+all: FOO $3 baz
+all:
+EOF
+
+  echo "Testcase: $1 $2 $3"
+  if echo "${mk}" | grep -q "^make"; then
+    # Make doesn't support .KATI_READONLY
+    echo "Makefile:4: *** cannot assign to readonly variable: FOO"
+  else
+    ${mk} 2>&1 && echo "Clean exit"
+  fi
+}
+
+#build "=" "=" "="
+#build "=" "+=" "="
+#build "=" ":=" "="
+#
+#build "=" ":=" ":="
+#build "=" ":=" "+="
+#
+#build ":=" ":=" ":="
+build ":=" ":=" "+="
+#build ":=" ":=" "="

--- a/testcase/readonly_rule_missing.sh
+++ b/testcase/readonly_rule_missing.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+#
+# Copyright 2016 Google Inc. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -u
+
+mk="$@"
+
+cat <<EOF > Makefile
+FOO = bar
+all: .KATI_READONLY = FOO
+all:
+EOF
+
+if echo "${mk}" | grep -q "^make"; then
+  # Make doesn't support .KATI_READONLY
+  echo "Makefile:2: *** unknown variable: FOO"
+else
+  ${mk} 2>&1 && echo "Clean exit"
+fi

--- a/var.cc
+++ b/var.cc
@@ -37,7 +37,7 @@ const char* GetOriginStr(VarOrigin origin) {
   return "*** broken origin ***";
 }
 
-Var::Var() {
+Var::Var() : readonly_(false) {
 }
 
 Var::~Var() {
@@ -130,10 +130,15 @@ Var* Vars::Lookup(Symbol name) const {
   return v;
 }
 
-void Vars::Assign(Symbol name, Var* v) {
+void Vars::Assign(Symbol name, Var* v, bool* readonly) {
+  *readonly = false;
   auto p = emplace(name, v);
   if (!p.second) {
     Var* orig = p.first->second;
+    if (orig->ReadOnly()) {
+      *readonly = true;
+      return;
+    }
     if (orig->Origin() == VarOrigin::OVERRIDE ||
         orig->Origin() == VarOrigin::ENVIRONMENT_OVERRIDE) {
       return;

--- a/var.h
+++ b/var.h
@@ -56,8 +56,14 @@ class Var : public Evaluable {
 
   virtual string DebugString() const = 0;
 
+  bool ReadOnly() const { return readonly_; }
+  void SetReadOnly() { readonly_ = true; }
+
  protected:
   Var();
+
+ private:
+  bool readonly_;
 };
 
 class SimpleVar : public Var {
@@ -177,7 +183,7 @@ class Vars : public unordered_map<Symbol, Var*> {
 
   Var* Lookup(Symbol name) const;
 
-  void Assign(Symbol name, Var* v);
+  void Assign(Symbol name, Var* v, bool* readonly);
 
   static void add_used_env_vars(Symbol v);
 


### PR DESCRIPTION
When the magic variable .KATI_READONLY is set to a variable name, any
further attempts to modify the named variable will result in an error.

  FOO := bar
  .KATI_READONLY := FOO
  FOO := baz  # Error!

This is useful to make some global configuration readonly so that
another makefile cannot change it. In Android, we emulated this by
backing up some global configuration before including the Android.mk
files, then comparing the current values to the backed up values after
they've been included. But this means we don't know the location that
modified the variable, just that something did. And it's not perfect,
since the backup can also be changed.

Something similar to this could be implemented with `override`, but then
setting the variable silently fails, and it still could be overriden
with another override.