### PR TITLE
Run regen commands sequentially

### DIFF
--- a/regen.cc
+++ b/regen.cc
@@ -375,8 +375,8 @@ class StampChecker {
         }
       });
 
-    for (ShellResult* sr : commands_) {
-      tp->Submit([this, sr]() {
+    tp->Submit([this]() {
+        for (ShellResult* sr : commands_) {
           string err;
           if (CheckShellResult(sr, &err)) {
             unique_lock<mutex> lock(mu_);
@@ -385,8 +385,8 @@ class StampChecker {
               msg_ = err;
             }
           }
-        });
-    }
+        }
+      });
 
     tp->Wait();
     if (needs_regen_) {


### PR DESCRIPTION
When I remove --ignore-dirty=$(OUT_DIR)/% from an Android build, it turns out that we have $(shell) commands that have side effects and cannot be reordered in relationship to one another. The trivial case is a sequence of 'rm', 'write', 'write'..., 'cmp'. The 'rm' and 'write' commands can be collapsed into a single $(file) function call, but it still needs to be ordered for the 'cmp' function to work properly.

I've been making changes to prevent this from slowing down regen too much, but it's still a 2-3x slowdown overall (0.3s -> 0.8s for aosp_arm64-eng on aosp master).