### PR TITLE
Improve error message for unreadable makefiles

### DIFF
--- a/eval.cc
+++ b/eval.cc
@@ -276,7 +276,9 @@ void Evaluator::EvalIf(const IfStmt* stmt) {
 
 void Evaluator::DoInclude(const string& fname) {
   Makefile* mk = MakefileCacheManager::Get()->ReadMakefile(fname);
-  CHECK(mk->Exists());
+  if (!mk->Exists()) {
+    Error(StringPrintf("Failed to read makefile: %s", fname.c_str()));
+  }
 
   Var* var_list = LookupVar(Intern("MAKEFILE_LIST"));
   var_list->AppendVar(this, NewLiteral(Intern(TrimLeadingCurdir(fname)).str()));


### PR DESCRIPTION
The simple way to trigger this is to remove the read permission from a
makefile, so it shows up in the file listing, but cannot be opened:

```
chmod a-r art/tools/Android.mk
```

But we see this occasionally on networked filesystems too, if there's a
network error reading the file. The current error message in this case
is not useful:

```
build/kati/eval.cc:279: mk->Exists()
```

Now it will print:

```
./art/Android.mk:80: Failed to read makefile: art/tools/Android.mk
```