### PR TITLE
Add a tool to export a kati stamp file to other tools

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -12,8 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+cc_defaults {
+    name: "ckati_defaults",
+    cflags: [
+        "-W",
+        "-Wall",
+        "-Werror",
+        "-DNOLOG",
+    ],
+    target: {
+        linux: {
+            host_ldlibs: ["-lrt", "-lpthread"],
+        },
+    },
+}
+
 cc_library_host_static {
     name: "libckati",
+    defaults: ["ckati_defaults"],
     srcs: [
         "affinity.cc",
         "command.cc",
@@ -44,25 +60,25 @@ cc_library_host_static {
         "var.cc",
         "version_unknown.cc",
     ],
-    cflags: ["-W", "-Wall", "-DNOLOG"],
 }
 
 cc_binary_host {
     name: "ckati",
-    srcs: [
-        "main.cc",
-    ],
+    defaults: ["ckati_defaults"],
+    srcs: ["main.cc"],
     whole_static_libs: ["libckati"],
-    cflags: ["-W", "-Wall", "-DNOLOG"],
-    target: {
-        linux: {
-            host_ldlibs: ["-lrt", "-lpthread"],
-        },
-    },
+}
+
+cc_binary_host {
+    name: "ckati_stamp_dump",
+    defaults: ["ckati_defaults"],
+    srcs: ["regen_dump.cc"],
+    whole_static_libs: ["libckati"],
 }
 
 cc_test_host {
     name: "ckati_test",
+    defaults: ["ckati_defaults"],
     test_per_src: true,
     srcs: [
         "find_test.cc",
@@ -73,22 +89,13 @@ cc_test_host {
     ],
     gtest: false,
     whole_static_libs: ["libckati"],
-    target: {
-        linux: {
-            host_ldlibs: ["-lrt", "-lpthread"],
-        },
-    },
 }
 
 cc_benchmark_host {
     name: "ckati_fileutil_bench",
+    defaults: ["ckati_defaults"],
     srcs: [
         "fileutil_bench.cc",
     ],
     whole_static_libs: ["libckati"],
-    target: {
-        linux: {
-            host_ldlibs: ["-lrt", "-lpthread"],
-        },
-    },
 }

--- a/regen_dump.cc
+++ b/regen_dump.cc
@@ -1,0 +1,57 @@
+// Copyright 2016 Google Inc. All rights reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build ignore
+
+// This command will dump the contents of a kati stamp file into a more portable
+// format for use by other tools. For now, it just exports the files read.
+// Later, this will be expanded to include the Glob and Shell commands, but
+// those require a more complicated output format.
+
+#include <stdio.h>
+
+#include <string>
+
+#include "io.h"
+#include "log.h"
+#include "strutil.h"
+
+int main(int argc, char* argv[]) {
+  if (argc == 1) {
+    fprintf(stderr, "Usage: ckati_stamp_dump <stamp>\n");
+    return 1;
+  }
+
+  FILE *fp = fopen(argv[1], "rb");
+  if(!fp)
+    PERROR("fopen");
+
+  ScopedFile sfp(fp);
+  double gen_time;
+  size_t r = fread(&gen_time, sizeof(gen_time), 1, fp);
+  if (r != 1)
+    ERROR("Incomplete stamp file");
+
+  int num_files = LoadInt(fp);
+  if (num_files < 0)
+    ERROR("Incomplete stamp file");
+  for (int i = 0; i < num_files; i++) {
+    string s;
+    if (!LoadString(fp, s))
+      ERROR("Incomplete stamp file");
+    printf("%s\n", s.c_str());
+  }
+
+  return 0;
+}


### PR DESCRIPTION
There's a desire to understand which files are used by a build so that
the automated builds can make better guesses at which builds should be
run for a certain change. Instead of having them read a stamp file
directly, which would prevent us from updating the stamp format in the
future, build a tool that can be used to export the contents in a stable
and more portable format.

Right now, this just means exporting the file list to stdout with
newlines as delimiters. An idea for the future is to define a protobuf
or similar format that would contain the glob and shell information as
well (if it's useful).