### PR TITLE
Update Android.bp to shrink executables

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -73,7 +73,7 @@ cc_binary_host {
     name: "ckati_stamp_dump",
     defaults: ["ckati_defaults"],
     srcs: ["regen_dump.cc"],
-    whole_static_libs: ["libckati"],
+    static_libs: ["libckati"],
 }
 
 cc_test_host {
@@ -88,7 +88,7 @@ cc_test_host {
         "strutil_test.cc",
     ],
     gtest: false,
-    whole_static_libs: ["libckati"],
+    static_libs: ["libckati"],
 }
 
 cc_benchmark_host {
@@ -97,5 +97,5 @@ cc_benchmark_host {
     srcs: [
         "fileutil_bench.cc",
     ],
-    whole_static_libs: ["libckati"],
+    static_libs: ["libckati"],
 }


### PR DESCRIPTION
Keep whole_static_libs for the main executable, but use static_libs for the rest. My goal is to check ckati_stamp_dump into Android as a prebuilt, and it goes from 2.4M->1.2M for the ASAN version, and 352K->11K for the normal version.