### PR TITLE
Allow rules to specify custom ninja pools

### DIFF
--- a/dep.cc
+++ b/dep.cc
@@ -231,6 +231,7 @@ DepNode::DepNode(Symbol o, bool p, bool r)
       is_restat(r),
       rule_vars(NULL),
       depfile_var(NULL),
+      ninja_pool_var(NULL),
       output_pattern(Symbol::IsUninitialized()) {
   g_dep_node_pool->push_back(this);
 }
@@ -244,7 +245,8 @@ class DepBuilder {
         rule_vars_(rule_vars),
         implicit_rules_(new RuleTrie()),
         first_rule_(Symbol::IsUninitialized{}),
-        depfile_var_name_(Intern(".KATI_DEPFILE")) {
+        depfile_var_name_(Intern(".KATI_DEPFILE")),
+        ninja_pool_var_name_(Intern(".KATI_NINJA_POOL")) {
     ScopedTimeReporter tr("make dep (populate)");
     PopulateRules(rules);
     // TODO?
@@ -607,6 +609,8 @@ class DepBuilder {
 
         if (name == depfile_var_name_) {
           n->depfile_var = new_var;
+        } else if (name == ninja_pool_var_name_) {
+          n->ninja_pool_var = new_var;
         } else {
           sv.emplace_back(new ScopedVar(cur_rule_vars_.get(), name, new_var));
         }
@@ -651,6 +655,7 @@ class DepBuilder {
   unordered_set<Symbol> phony_;
   unordered_set<Symbol> restat_;
   Symbol depfile_var_name_;
+  Symbol ninja_pool_var_name_;
 };
 
 void MakeDep(Evaluator* ev,

--- a/dep.h
+++ b/dep.h
@@ -45,6 +45,7 @@ struct DepNode {
   vector<Symbol> actual_order_only_inputs;
   Vars* rule_vars;
   Var* depfile_var;
+  Var* ninja_pool_var;
   Symbol output_pattern;
   Loc loc;
 };

--- a/ninja.cc
+++ b/ninja.cc
@@ -561,8 +561,13 @@ class NinjaGenerator {
       }
     }
     *o << "\n";
-    if (use_local_pool)
+    if (node->ninja_pool_var) {
+      string pool;
+      node->ninja_pool_var->Eval(ev_, &pool);
+      *o << " pool = " << pool << "\n";
+    } else if (use_local_pool) {
       *o << " pool = local_pool\n";
+    }
     if (node->is_default_target) {
       unique_lock<mutex> lock(mu_);
       default_target_ = node;

--- a/testcase/ninja_pool.sh
+++ b/testcase/ninja_pool.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+#
+# Copyright 2016 Google Inc. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+log=/tmp/log
+mk="$@"
+
+cat <<EOF > Makefile
+
+test: .KATI_NINJA_POOL := test_pool
+test:
+	echo "PASS"
+EOF
+
+${mk} 2>${log}
+if [ -e ninja.sh ]; then
+  mv build.ninja kati.ninja
+  cat <<EOF > build.ninja
+pool test_pool
+  depth = 1
+include kati.ninja
+EOF
+  ./ninja.sh
+fi
+if [ -e ninja.sh ]; then
+  if ! grep -q "pool = test_pool" kati.ninja; then
+    echo "Pool not present in build.ninja"
+  fi
+fi


### PR DESCRIPTION
Setting .KATI_NINJA_POOL as a rule variable will set the corresponding pool variable in the ninja file.

There's no way to define custom pools in Kati, Android is planning on scaling the pool depth in a parent ninja file without re-running Kati.