### PR TITLE
[go] Fix can't the build kati binary

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,5 +9,6 @@
 # Please keep the list sorted.
 
 Google Inc.
+Koichi Shiraishi <zchee.io@gmail.com>
 Kouhei Sutou <kou@cozmixng.org>
 Po Hu <hupo1985@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -25,6 +25,7 @@
 Colin Cross <ccross@google.com>
 Dan Willemsen <dwillemsen@google.com>
 Fumitoshi Ukai <ukai@google.com>
+Koichi Shiraishi <zchee.io@gmail.com>
 Kouhei Sutou <kou@cozmixng.org>
 Po Hu <hupo1985@gmail.com>
 Ryo Hashimoto <hashimoto@google.com>

--- a/Makefile.kati
+++ b/Makefile.kati
@@ -22,7 +22,7 @@ endif
 
 kati: go_src_stamp
 	-rm -f out/bin/kati
-	GOPATH=${KATI_GOPATH} go install -ldflags "-X github.com/google/kati.gitVersion $(shell git rev-parse HEAD)" github.com/google/kati/cmd/kati
+	GOPATH=${KATI_GOPATH} go install -ldflags "-X github.com/google/kati.gitVersion=$(shell git rev-parse HEAD)" github.com/google/kati/cmd/kati
 	cp out/bin/kati $@
 
 go_src_stamp: $(GO_SRCS) $(wildcard cmd/*/*.go)

--- a/affinity.cc
+++ b/affinity.cc
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build ignore
+
 #include "affinity.h"
 
 #include "flags.h"

--- a/fileutil_bench.cc
+++ b/fileutil_bench.cc
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build ignore
+
 #include "fileutil.h"
 #include <benchmark/benchmark.h>
 #include <cstdio>

--- a/pathutil.go
+++ b/pathutil.go
@@ -191,7 +191,7 @@ func (c *fsCacheT) readdir(dir string, id fileid) (fileid, []dirent) {
 		return invalidFileid, nil
 	}
 	if stat, ok := fi.Sys().(*syscall.Stat_t); ok {
-		id = fileid{dev: stat.Dev, ino: stat.Ino}
+		id = fileid{dev: uint64(stat.Dev), ino: stat.Ino}
 	}
 	names, _ := d.Readdirnames(-1)
 	// need sort?
@@ -209,7 +209,7 @@ func (c *fsCacheT) readdir(dir string, id fileid) (fileid, []dirent) {
 		mode := lmode
 		var id fileid
 		if stat, ok := fi.Sys().(*syscall.Stat_t); ok {
-			id = fileid{dev: stat.Dev, ino: stat.Ino}
+			id = fileid{dev: uint64(stat.Dev), ino: stat.Ino}
 		}
 		if lmode&os.ModeSymlink == os.ModeSymlink {
 			fi, err = os.Stat(path)
@@ -218,7 +218,7 @@ func (c *fsCacheT) readdir(dir string, id fileid) (fileid, []dirent) {
 			} else {
 				mode = fi.Mode()
 				if stat, ok := fi.Sys().(*syscall.Stat_t); ok {
-					id = fileid{dev: stat.Dev, ino: stat.Ino}
+					id = fileid{dev: uint64(stat.Dev), ino: stat.Ino}
 				}
 			}
 		}

--- a/regen.cc
+++ b/regen.cc
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build ignore
+
 #include "regen.h"
 
 #include <sys/stat.h>

--- a/strutil_bench.cc
+++ b/strutil_bench.cc
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build ignore
+
 #include <string>
 #include <vector>
 

--- a/thread_pool.cc
+++ b/thread_pool.cc
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// +build ignore
+
 #include "thread_pool.h"
 
 #include <condition_variable>


### PR DESCRIPTION
Fix can't build the kati binary.

- [[go] fix stat.Dev type to uint64](https://github.com/google/kati/commit/e99f57f8b49cf662e9149c962b7ffbcafc9a07fc)
- [[go] fix ldflags foramt to add '=' for -X flag](https://github.com/google/kati/commit/0a2453a1bcd3ee9113a8d695113c5de6cb1ed542)
- [[C++] add +build ignore magic comment for go build](https://github.com/google/kati/commit/df8cd0596bc8b7a92767d9290fdce59fd4355460)

---

At the first, Sorry for this pull request disrupt the development of main line(C++).
And I know `google/kati` has been changed from Go to C++. (IIRC caused by Go's Generational Garbage Collection, right?)

However, I think kati's `.go` code still very good references for internal implementation of `make`, and how to writing a parser. Also, kati is the only Go package for `Makefile`.
So, I'm glad if kati will keep the buildable state for Go.

But `+build ignore` magic comment certainly hinders the development of C++. I'm thinking to fork kati and keep *"buildable"* on my own repository.
What do you think about it?

Thanks for the great code. I learned a lot of from it.