### PR TITLE
Remove error message when filesystem loop detected

### DIFF
--- a/find.cc
+++ b/find.cc
@@ -261,9 +261,7 @@ class DirentDirNode : public DirentNode {
                        vector<string>& out) const override {
     ScopedReadDirTracker srdt(this, *path, cur_read_dirs);
     if (!srdt.ok()) {
-      fprintf(stderr, "FindEmulator: find: File system loop detected; `%s' is "
-              "part of the same file system loop as `%s'.\n",
-              path->c_str(), srdt.conflicted().c_str());
+      // filesystem loop detected
       return true;
     }
 


### PR DESCRIPTION
Filesystem loops are not an error, remove the diagnostic message
when they are detected.

Change-Id: I5d261e9c533dce4f97a7fa08613d2332b531e3cd