### PR TITLE
nit: [AUTHORS] Fix kati instead of glog

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,4 +1,4 @@
-# This is the official list of glog authors for copyright purposes.
+# This is the official list of kati authors for copyright purposes.
 # This file is distinct from the CONTRIBUTORS files.
 # See the latter for an explanation.
 #


### PR DESCRIPTION
Sorry for nit pull request.

I don't know Google's `AUTHORS` file policy, but it seems to use project(or repository) name.
So, Is `glog` is a typo?