### PR TITLE
Improve and color warnings (with --color_warnings)

### DIFF
--- a/dep.cc
+++ b/dep.cc
@@ -156,16 +156,18 @@ struct RuleMerger {
     if (rules.empty()) {
       is_double_colon = r->is_double_colon;
     } else if (is_double_colon != r->is_double_colon) {
-      ERROR("%s:%d: *** target file `%s' has both : and :: entries.",
-            LOCF(r->loc), output.c_str());
+      ERROR_LOC(r->loc, "*** target file `%s' has both : and :: entries.",
+                output.c_str());
     }
 
     if (primary_rule && !r->cmds.empty() &&
         !IsSuffixRule(output) && !r->is_double_colon) {
-      WARN("%s:%d: warning: overriding commands for target `%s'",
-           LOCF(r->cmd_loc()), output.c_str());
-      WARN("%s:%d: warning: ignoring old commands for target `%s'",
-           LOCF(primary_rule->cmd_loc()), output.c_str());
+      WARN_LOC(r->cmd_loc(),
+               "warning: overriding commands for target `%s'",
+               output.c_str());
+      WARN_LOC(primary_rule->cmd_loc(),
+               "warning: ignoring old commands for target `%s'",
+               output.c_str());
       primary_rule = r;
     }
     if (!primary_rule && !r->cmds.empty()) {
@@ -274,8 +276,7 @@ class DepBuilder {
       if (targets.empty()) {
         suffix_rules_.clear();
       } else {
-        WARN("%s:%d: kati doesn't support .SUFFIXES with prerequisites",
-             LOCF(loc));
+        WARN_LOC(loc, "kati doesn't support .SUFFIXES with prerequisites");
       }
     }
 
@@ -296,7 +297,7 @@ class DepBuilder {
     };
     for (const char** p = kUnsupportedBuiltinTargets; *p; p++) {
       if (GetRuleInputs(Intern(*p), &targets, &loc)) {
-        WARN("%s:%d: kati doesn't support %s", LOCF(loc), *p);
+        WARN_LOC(loc, "kati doesn't support %s", *p);
       }
     }
   }

--- a/eval.cc
+++ b/eval.cc
@@ -383,7 +383,7 @@ string Evaluator::GetShellAndFlag() {
 }
 
 void Evaluator::Error(const string& msg) {
-  ERROR("%s:%d: %s", LOCF(loc_), msg.c_str());
+  ERROR_LOC(loc_, "%s", msg.c_str());
 }
 
 unordered_set<Symbol> Evaluator::used_undefined_vars_;

--- a/expr.cc
+++ b/expr.cc
@@ -317,9 +317,9 @@ void ParseFunc(const Loc& loc,
     f->AddArg(v);
     i += n;
     if (i == s.size()) {
-      ERROR("%s:%d: *** unterminated call to function '%s': "
-            "missing '%c'.",
-            LOCF(loc), f->name(), terms[0]);
+      ERROR_LOC(loc, "*** unterminated call to function '%s': "
+                "missing '%c'.",
+                f->name(), terms[0]);
     }
     nargs++;
     if (s[i] == terms[0]) {
@@ -332,8 +332,8 @@ void ParseFunc(const Loc& loc,
   }
 
   if (nargs <= f->min_arity()) {
-    ERROR("%s:%d: *** insufficient number of arguments (%d) to function `%s'.",
-          LOCF(loc), nargs - 1, f->name());
+    ERROR_LOC(loc, "*** insufficient number of arguments (%d) to function `%s'.",
+              nargs - 1, f->name());
   }
 
   *index_out = i;
@@ -365,8 +365,8 @@ Value* ParseDollar(const Loc& loc, StringPiece s, size_t* index_out) {
         if (g_flags.enable_kati_warnings) {
           size_t found = sym.str().find_first_of(" ({");
           if (found != string::npos) {
-            KATI_WARN("%s:%d: *warning*: variable lookup with '%c': %.*s",
-                      loc, sym.str()[found], SPF(s));
+            KATI_WARN_LOC(loc, "*warning*: variable lookup with '%c': %.*s",
+                          sym.str()[found], SPF(s));
           }
         }
         Value* r = new SymRef(sym);
@@ -386,8 +386,8 @@ Value* ParseDollar(const Loc& loc, StringPiece s, size_t* index_out) {
           ParseFunc(loc, func, s, i+1, terms, index_out);
           return func;
         } else {
-          KATI_WARN("%s:%d: *warning*: unknown make function '%.*s': %.*s",
-                    loc, SPF(lit->val()), SPF(s));
+          KATI_WARN_LOC(loc, "*warning*: unknown make function '%.*s': %.*s",
+                        SPF(lit->val()), SPF(s));
         }
       }
 
@@ -428,12 +428,12 @@ Value* ParseDollar(const Loc& loc, StringPiece s, size_t* index_out) {
     // for detail.
     size_t found = s.find(cp);
     if (found != string::npos) {
-      KATI_WARN("%s:%d: *warning*: unmatched parentheses: %.*s",
-                loc, SPF(s));
+      KATI_WARN_LOC(loc, "*warning*: unmatched parentheses: %.*s",
+                    SPF(s));
       *index_out = s.size();
       return new SymRef(Intern(s.substr(2, found-2)));
     }
-    ERROR("%s:%d: *** unterminated variable reference.", LOCF(loc));
+    ERROR_LOC(loc, "*** unterminated variable reference.");
   }
 }
 

--- a/find.cc
+++ b/find.cc
@@ -150,7 +150,7 @@ class DirentNode {
   virtual const DirentNode* FindDir(StringPiece) const {
     return NULL;
   }
-  virtual bool RunFind(const FindCommand& fc, int d,
+  virtual bool RunFind(const FindCommand& fc, const Loc& loc, int d,
                        string* path,
                        unordered_map<const DirentNode*, string>* cur_read_dirs,
                        vector<string>& out) const = 0;
@@ -185,7 +185,7 @@ class DirentFileNode : public DirentNode {
       : DirentNode(name), type_(type) {
   }
 
-  virtual bool RunFind(const FindCommand& fc, int d,
+  virtual bool RunFind(const FindCommand& fc, const Loc&, int d,
                        string* path,
                        unordered_map<const DirentNode*, string>*,
                        vector<string>& out) const override {
@@ -255,15 +255,15 @@ class DirentDirNode : public DirentNode {
     return NULL;
   }
 
-  virtual bool RunFind(const FindCommand& fc, int d,
+  virtual bool RunFind(const FindCommand& fc, const Loc& loc, int d,
                        string* path,
                        unordered_map<const DirentNode*, string>* cur_read_dirs,
                        vector<string>& out) const override {
     ScopedReadDirTracker srdt(this, *path, cur_read_dirs);
     if (!srdt.ok()) {
-      fprintf(stderr, "FindEmulator: find: File system loop detected; `%s' is "
-              "part of the same file system loop as `%s'.\n",
-              path->c_str(), srdt.conflicted().c_str());
+      WARN_LOC(loc, "FindEmulator: find: File system loop detected; `%s' "
+               "is part of the same file system loop as `%s'.",
+               path->c_str(), srdt.conflicted().c_str());
       return true;
     }
 
@@ -292,7 +292,7 @@ class DirentDirNode : public DirentNode {
         if ((*path)[path->size()-1] != '/')
           *path += '/';
         *path += c->base();
-        if (!c->RunFind(fc, d + 1, path, cur_read_dirs, out))
+        if (!c->RunFind(fc, loc, d + 1, path, cur_read_dirs, out))
           return false;
         path->resize(orig_path_size);
       }
@@ -320,7 +320,7 @@ class DirentDirNode : public DirentNode {
         if ((*path)[path->size()-1] != '/')
           *path += '/';
         *path += c->base();
-        if (!c->RunFind(fc, d + 1, path, cur_read_dirs, out))
+        if (!c->RunFind(fc, loc, d + 1, path, cur_read_dirs, out))
           return false;
         path->resize(orig_path_size);
       }
@@ -330,7 +330,7 @@ class DirentDirNode : public DirentNode {
         if ((*path)[path->size()-1] != '/')
           *path += '/';
         *path += c->base();
-        if (!c->RunFind(fc, d + 1, path, cur_read_dirs, out))
+        if (!c->RunFind(fc, loc, d + 1, path, cur_read_dirs, out))
           return false;
         path->resize(orig_path_size);
       }
@@ -360,7 +360,7 @@ class DirentSymlinkNode : public DirentNode {
     return NULL;
   }
 
-  virtual bool RunFind(const FindCommand& fc, int d,
+  virtual bool RunFind(const FindCommand& fc, const Loc& loc, int d,
                        string* path,
                        unordered_map<const DirentNode*, string>* cur_read_dirs,
                        vector<string>& out) const override {
@@ -368,8 +368,8 @@ class DirentSymlinkNode : public DirentNode {
     if (fc.follows_symlinks && errno_ != ENOENT) {
       if (errno_) {
         if (fc.type != FindCommandType::FINDLEAVES) {
-          fprintf(stderr, "FindEmulator: find: `%s': %s\n",
-                  path->c_str(), strerror(errno_));
+          WARN_LOC(loc, "FindEmulator: find: `%s': %s",
+                   path->c_str(), strerror(errno_));
         }
         return true;
       }
@@ -379,7 +379,7 @@ class DirentSymlinkNode : public DirentNode {
         return false;
       }
 
-      return to_->RunFind(fc, d, path, cur_read_dirs, out);
+      return to_->RunFind(fc, loc, d, path, cur_read_dirs, out);
     }
     PrintIfNecessary(fc, *path, type, d, out);
     return true;
@@ -783,7 +783,7 @@ class FindEmulatorImpl : public FindEmulator {
   }
 
   virtual bool HandleFind(const string& cmd UNUSED, const FindCommand& fc,
-                          string* out) override {
+                          const Loc& loc, string* out) override {
     if (!CanHandle(fc.chdir)) {
       LOG("FindEmulator: Cannot handle chdir (%.*s): %s",
           SPF(fc.chdir), cmd.c_str());
@@ -823,9 +823,8 @@ class FindEmulatorImpl : public FindEmulator {
         if (should_fallback)
           return false;
         if (!fc.redirect_to_devnull) {
-          fprintf(stderr,
-                  "FindEmulator: cd: %.*s: No such file or directory\n",
-                  SPF(fc.chdir));
+          WARN_LOC(loc, "FindEmulator: cd: %.*s: No such file or directory",
+                   SPF(fc.chdir));
         }
         return true;
       }
@@ -848,16 +847,15 @@ class FindEmulatorImpl : public FindEmulator {
           return false;
         }
         if (!fc.redirect_to_devnull) {
-          fprintf(stderr,
-                  "FindEmulator: find: `%s': No such file or directory\n",
-                  ConcatDir(fc.chdir, finddir).c_str());
+          WARN_LOC(loc, "FindEmulator: find: `%s': No such file or directory",
+                   ConcatDir(fc.chdir, finddir).c_str());
         }
         continue;
       }
 
       string path = finddir;
       unordered_map<const DirentNode*, string> cur_read_dirs;
-      if (!base->RunFind(fc, 0, &path, &cur_read_dirs, results)) {
+      if (!base->RunFind(fc, loc, 0, &path, &cur_read_dirs, results)) {
         LOG("FindEmulator: RunFind failed: %s", cmd.c_str());
         return false;
       }

--- a/find.h
+++ b/find.h
@@ -20,6 +20,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include "loc.h"
 #include "string_piece.h"
 
 using namespace std;
@@ -62,7 +63,7 @@ class FindEmulator {
   virtual ~FindEmulator() = default;
 
   virtual bool HandleFind(const string& cmd, const FindCommand& fc,
-                          string* out) = 0;
+                          const Loc& loc, string* out) = 0;
 
   static FindEmulator* Get();
 

--- a/find_test.cc
+++ b/find_test.cc
@@ -39,7 +39,7 @@ int main(int argc, char* argv[]) {
     return 1;
   }
   string out;
-  if (!FindEmulator::Get()->HandleFind(cmd, fc, &out)) {
+  if (!FindEmulator::Get()->HandleFind(cmd, fc, Loc(), &out)) {
     fprintf(stderr, "Find emulator does not support this command\n");
     return 1;
   }

--- a/flags.cc
+++ b/flags.cc
@@ -97,6 +97,8 @@ void Flags::Parse(int argc, char** argv) {
       detect_android_echo = true;
     } else if (!strcmp(arg, "--detect_depfiles")) {
       detect_depfiles = true;
+    } else if (!strcmp(arg, "--color_warnings")) {
+      color_warnings = true;
     } else if (ParseCommandLineOptionWithArg(
         "-j", argv, &i, &num_jobs_str)) {
       num_jobs = strtol(num_jobs_str, NULL, 10);

--- a/flags.h
+++ b/flags.h
@@ -39,6 +39,7 @@ struct Flags {
   bool regen_debug;
   bool regen_ignoring_kati_binary;
   bool use_find_emulator;
+  bool color_warnings;
   const char* goma_dir;
   const char* ignore_dirty_pattern;
   const char* no_ignore_dirty_pattern;

--- a/func.cc
+++ b/func.cc
@@ -494,7 +494,8 @@ static bool HasNoIoInShellScript(const string& cmd) {
 }
 
 static void ShellFuncImpl(const string& shell, const string& shellflag,
-                          const string& cmd, string* s, FindCommand** fc) {
+                          const string& cmd, const Loc& loc, string* s,
+                          FindCommand** fc) {
   LOG("ShellFunc: %s", cmd.c_str());
 
 #ifdef TEST_FIND_EMULATOR
@@ -505,11 +506,11 @@ static void ShellFuncImpl(const string& shell, const string& shellflag,
     *fc = new FindCommand();
     if ((*fc)->Parse(cmd)) {
 #ifdef TEST_FIND_EMULATOR
-      if (FindEmulator::Get()->HandleFind(cmd, **fc, &out2)) {
+      if (FindEmulator::Get()->HandleFind(cmd, **fc, loc, &out2)) {
         need_check = true;
       }
 #else
-      if (FindEmulator::Get()->HandleFind(cmd, **fc, s)) {
+      if (FindEmulator::Get()->HandleFind(cmd, **fc, loc, s)) {
         return;
       }
 #endif
@@ -571,7 +572,7 @@ void ShellFunc(const vector<Value*>& args, Evaluator* ev, string* s) {
 
   string out;
   FindCommand* fc = NULL;
-  ShellFuncImpl(shell, shellflag, cmd, &out, &fc);
+  ShellFuncImpl(shell, shellflag, cmd, ev->loc(), &out, &fc);
   if (ShouldStoreCommandResult(cmd)) {
     CommandResult* cr = new CommandResult();
     cr->op = (fc == NULL) ? CommandOp::SHELL : CommandOp::FIND,

--- a/func.cc
+++ b/func.cc
@@ -466,8 +466,8 @@ void EvalFunc(const vector<Value*>& args, Evaluator* ev, string*) {
   string* text = new string;
   args[0]->Eval(ev, text);
   if (ev->avoid_io()) {
-    KATI_WARN("%s:%d: *warning*: $(eval) in a recipe is not recommended: %s",
-              LOCF(ev->loc()), text->c_str());
+    KATI_WARN_LOC(ev->loc(), "*warning*: $(eval) in a recipe is not recommended: %s",
+                  text->c_str());
   }
   vector<Stmt*> stmts;
   Parse(*text, ev->loc(), &stmts);
@@ -555,9 +555,9 @@ void ShellFunc(const vector<Value*>& args, Evaluator* ev, string* s) {
   string cmd = args[0]->Eval(ev);
   if (ev->avoid_io() && !HasNoIoInShellScript(cmd)) {
     if (ev->eval_depth() > 1) {
-      ERROR("%s:%d: kati doesn't support passing results of $(shell) "
-            "to other make constructs: %s",
-            LOCF(ev->loc()), cmd.c_str());
+      ERROR_LOC(ev->loc(), "kati doesn't support passing results of $(shell) "
+                "to other make constructs: %s",
+                cmd.c_str());
     }
     StripShellComment(&cmd);
     *s += "$(";
@@ -595,8 +595,8 @@ void CallFunc(const vector<Value*>& args, Evaluator* ev, string* s) {
   const StringPiece func_name = TrimSpace(func_name_buf);
   Var* func = ev->LookupVar(Intern(func_name));
   if (!func->IsDefined()) {
-    KATI_WARN("%s:%d: *warning*: undefined user function: %s",
-              ev->loc(), func_name.as_string().c_str());
+    KATI_WARN_LOC(ev->loc(), "*warning*: undefined user function: %s",
+                  func_name.as_string().c_str());
   }
   vector<unique_ptr<SimpleVar>> av;
   for (size_t i = 1; i < args.size(); i++) {
@@ -676,8 +676,7 @@ void WarningFunc(const vector<Value*>& args, Evaluator* ev, string*) {
         StringPrintf("echo -e \"%s:%d: %s\" 2>&1", LOCF(ev->loc()), EchoEscape(a).c_str()));
     return;
   }
-  printf("%s:%d: %s\n", LOCF(ev->loc()), a.c_str());
-  fflush(stdout);
+  WARN_LOC(ev->loc(), "%s", a.c_str());
 }
 
 void ErrorFunc(const vector<Value*>& args, Evaluator* ev, string*) {

--- a/log.cc
+++ b/log.cc
@@ -16,5 +16,46 @@
 
 #include "log.h"
 
+#include "flags.h"
+#include "strutil.h"
+
+#define BOLD "\033[1m"
+#define RESET "\033[0m"
+#define MAGENTA "\033[35m"
+#define RED "\033[31m"
+
+void ColorErrorLog(const char* file, int line, const char* msg) {
+  if (file == nullptr) {
+    ERROR("%s", msg);
+    return;
+  }
+
+  if (g_flags.color_warnings) {
+    StringPiece filtered = TrimPrefix(msg, "*** ");
+
+    ERROR(BOLD "%s:%d: " RED "error: " RESET BOLD "%s" RESET,
+          file, line, filtered.as_string().c_str());
+  } else {
+    ERROR("%s:%d: %s", file, line, msg);
+  }
+}
+
+void ColorWarnLog(const char* file, int line, const char* msg) {
+  if (file == nullptr) {
+    fprintf(stderr, "%s\n", msg);
+    return;
+  }
+
+  if (g_flags.color_warnings) {
+    StringPiece filtered = TrimPrefix(msg, "*warning*: ");
+    filtered = TrimPrefix(filtered, "warning: ");
+
+    fprintf(stderr, BOLD "%s:%d: " MAGENTA "warning: " RESET BOLD "%s" RESET "\n",
+            file, line, filtered.as_string().c_str());
+  } else {
+    fprintf(stderr, "%s:%d: %s\n", file, line, msg);
+  }
+}
+
 bool g_log_no_exit;
 string* g_last_error;

--- a/log.h
+++ b/log.h
@@ -21,6 +21,7 @@
 #include <string.h>
 
 #include "flags.h"
+#include "log.h"
 #include "stringprintf.h"
 
 using namespace std;
@@ -72,5 +73,23 @@ extern string* g_last_error;
   } while (0)
 
 #define CHECK(c) if (!(c)) ERROR("%s:%d: %s", __FILE__, __LINE__, #c)
+
+// Set of logging functions that will automatically colorize lines that have
+// location information when --color_warnings is set.
+void ColorWarnLog(const char* file, int line, const char *msg);
+void ColorErrorLog(const char* file, int line, const char *msg);
+
+#define WARN_LOC(loc, ...) do {                                 \
+    ColorWarnLog(LOCF(loc), StringPrintf(__VA_ARGS__).c_str()); \
+  } while (0)
+
+#define KATI_WARN_LOC(loc, ...) do {                                  \
+    if (g_flags.enable_kati_warnings)                             \
+      ColorWarnLog(LOCF(loc), StringPrintf(__VA_ARGS__).c_str()); \
+  } while(0)
+
+#define ERROR_LOC(loc, ...) do {                                 \
+    ColorErrorLog(LOCF(loc), StringPrintf(__VA_ARGS__).c_str()); \
+  } while (0)
 
 #endif  // LOG_H_

--- a/main.cc
+++ b/main.cc
@@ -173,8 +173,8 @@ static int Run(const vector<Symbol>& targets,
   }
 
   for (ParseErrorStmt* err : GetParseErrors()) {
-    WARN("%s:%d: warning for parse error in an unevaluated line: %s",
-         LOCF(err->loc()), err->msg.c_str());
+    WARN_LOC(err->loc(), "warning for parse error in an unevaluated line: %s",
+             err->msg.c_str());
   }
 
   vector<DepNode*> nodes;

--- a/parser.cc
+++ b/parser.cc
@@ -92,10 +92,10 @@ class Parser {
     }
 
     if (!if_stack_.empty())
-      ERROR("%s:%d: *** missing `endif'.", loc_.filename, loc_.lineno + 1);
+      ERROR_LOC(Loc(loc_.filename, loc_.lineno + 1), "*** missing `endif'.");
     if (!define_name_.empty())
-      ERROR("%s:%d: *** missing `endef', unterminated `define'.",
-            loc_.filename, define_start_line_);
+      ERROR_LOC(Loc(loc_.filename, define_start_line_),
+                "*** missing `endef', unterminated `define'.");
   }
 
   static void Init() {
@@ -304,7 +304,7 @@ class Parser {
     StringPiece rest = TrimRightSpace(RemoveComment(TrimLeftSpace(
         line.substr(sizeof("endef")))));
     if (!rest.empty()) {
-      WARN("%s:%d: extraneous text after `endef' directive", LOCF(loc_));
+      WARN_LOC(loc_, "extraneous text after `endef' directive");
     }
 
     AssignStmt* stmt = new AssignStmt();
@@ -374,7 +374,7 @@ class Parser {
       }
     }
     if (!s.empty()) {
-      WARN("%s:%d: extraneous text after `ifeq' directive", LOCF(loc_));
+      WARN_LOC(loc_, "extraneous text after `ifeq' directive");
       return true;
     }
     return true;
@@ -411,7 +411,7 @@ class Parser {
 
     num_if_nest_ = st->num_nest + 1;
     if (!HandleDirective(next_if, else_if_directives_)) {
-      WARN("%s:%d: extraneous text after `else' directive", LOCF(loc_));
+      WARN_LOC(loc_, "extraneous text after `else' directive");
     }
     num_if_nest_ = 0;
   }

--- a/rule.cc
+++ b/rule.cc
@@ -58,7 +58,7 @@ void ParseRule(Loc& loc, StringPiece line, char term,
                Rule** out_rule, RuleVarAssignment* rule_var) {
   size_t index = line.find(':');
   if (index == string::npos) {
-    ERROR("%s:%d: *** missing separator.", LOCF(loc));
+    ERROR_LOC(loc, "*** missing separator.");
   }
 
   StringPiece first = line.substr(0, index);
@@ -71,8 +71,7 @@ void ParseRule(Loc& loc, StringPiece line, char term,
       !outputs.empty() && IsPatternRule(outputs[0].str()));
   for (size_t i = 1; i < outputs.size(); i++) {
     if (IsPatternRule(outputs[i].str()) != is_first_pattern) {
-      ERROR("%s:%d: *** mixed implicit and normal rules: deprecated syntax",
-            LOCF(loc));
+      ERROR_LOC(loc, "*** mixed implicit and normal rules: deprecated syntax");
     }
   }
 
@@ -94,8 +93,8 @@ void ParseRule(Loc& loc, StringPiece line, char term,
     // target specific variable).
     // See https://github.com/google/kati/issues/83
     if (term_index == 0) {
-      KATI_WARN("%s:%d: defining a target which starts with `=', "
-                "which is not probably what you meant", LOCF(loc));
+      KATI_WARN_LOC(loc, "defining a target which starts with `=', "
+                    "which is not probably what you meant");
       buf = line.as_string();
       if (term)
         buf += term;
@@ -136,8 +135,7 @@ void ParseRule(Loc& loc, StringPiece line, char term,
   }
 
   if (is_first_pattern) {
-    ERROR("%s:%d: *** mixed implicit and normal rules: deprecated syntax",
-          LOCF(loc));
+    ERROR_LOC(loc, "*** mixed implicit and normal rules: deprecated syntax");
   }
 
   StringPiece second = rest.substr(0, index);
@@ -147,8 +145,8 @@ void ParseRule(Loc& loc, StringPiece line, char term,
     tok = TrimLeadingCurdir(tok);
     for (Symbol output : rule->outputs) {
       if (!Pattern(tok).Match(output.str())) {
-        WARN("%s:%d: target `%s' doesn't match the target pattern",
-             LOCF(loc), output.c_str());
+        WARN_LOC(loc, "target `%s' doesn't match the target pattern",
+                 output.c_str());
       }
     }
 
@@ -156,13 +154,13 @@ void ParseRule(Loc& loc, StringPiece line, char term,
   }
 
   if (rule->output_patterns.empty()) {
-    ERROR("%s:%d: *** missing target pattern.", LOCF(loc));
+    ERROR_LOC(loc, "*** missing target pattern.");
   }
   if (rule->output_patterns.size() > 1) {
-    ERROR("%s:%d: *** multiple target patterns.", LOCF(loc));
+    ERROR_LOC(loc, "*** multiple target patterns.");
   }
   if (!IsPatternRule(rule->output_patterns[0].str())) {
-    ERROR("%s:%d: *** target pattern contains no '%%'.", LOCF(loc));
+    ERROR_LOC(loc, "*** target pattern contains no '%%'.");
   }
   ParseInputs(rule, third);
 }

--- a/rule.h
+++ b/rule.h
@@ -49,7 +49,7 @@ class Rule {
 
  private:
   void Error(const string& msg) {
-    ERROR("%s:%d: %s", loc.filename, loc.lineno, msg.c_str());
+    ERROR_LOC(loc, "%s", msg.c_str());
   }
 };
 

--- a/runtest.rb
+++ b/runtest.rb
@@ -170,7 +170,7 @@ def normalize_kati_log(output)
   output.gsub!(/\/bin\/sh: ([^:]*): command not found/,
                "\\1: Command not found")
   output.gsub!(/.*: warning for parse error in an unevaluated line: .*\n/, '')
-  output.gsub!(/^FindEmulator: /, '')
+  output.gsub!(/^([^ ]+: )?FindEmulator: /, '')
   output.gsub!(/^\/bin\/sh: line 0: /, '')
   output.gsub!(/ (\.\/+)+kati\.\S+/, '') # kati log files in find_command.mk
   output.gsub!(/ (\.\/+)+test\S+.json/, '') # json files in find_command.mk

--- a/strutil.cc
+++ b/strutil.cc
@@ -174,6 +174,13 @@ bool HasWord(StringPiece str, StringPiece w) {
   return true;
 }
 
+StringPiece TrimPrefix(StringPiece str, StringPiece prefix) {
+  ssize_t size_diff = str.size() - prefix.size();
+  if (size_diff < 0 || str.substr(0, prefix.size()) != prefix)
+    return str;
+  return str.substr(prefix.size());
+}
+
 StringPiece TrimSuffix(StringPiece str, StringPiece suffix) {
   ssize_t size_diff = str.size() - suffix.size();
   if (size_diff < 0 || str.substr(size_diff) != suffix)

--- a/strutil.h
+++ b/strutil.h
@@ -89,6 +89,8 @@ bool HasSuffix(StringPiece str, StringPiece suffix);
 
 bool HasWord(StringPiece str, StringPiece w);
 
+StringPiece TrimPrefix(StringPiece str, StringPiece suffix);
+
 StringPiece TrimSuffix(StringPiece str, StringPiece suffix);
 
 class Pattern {

--- a/strutil_test.cc
+++ b/strutil_test.cc
@@ -56,6 +56,20 @@ void TestHasSuffix() {
   assert(!HasSuffix("bar", "bbar"));
 }
 
+void TestTrimPrefix() {
+  ASSERT_EQ(TrimPrefix("foo", "foo"), "");
+  ASSERT_EQ(TrimPrefix("foo", "fo"), "o");
+  ASSERT_EQ(TrimPrefix("foo", ""), "foo");
+  ASSERT_EQ(TrimPrefix("foo", "fooo"), "foo");
+}
+
+void TestTrimSuffix() {
+  ASSERT_EQ(TrimSuffix("bar", "bar"), "");
+  ASSERT_EQ(TrimSuffix("bar", "ar"), "b");
+  ASSERT_EQ(TrimSuffix("bar", ""), "bar");
+  ASSERT_EQ(TrimSuffix("bar", "bbar"), "bar");
+}
+
 string SubstPattern(StringPiece str, StringPiece pat, StringPiece subst) {
   string r;
   Pattern(pat).AppendSubst(str, subst, &r);
@@ -190,6 +204,8 @@ int main() {
   TestWordScanner();
   TestHasPrefix();
   TestHasSuffix();
+  TestTrimPrefix();
+  TestTrimSuffix();
   TestSubstPattern();
   TestNoLineBreak();
   TestHasWord();


### PR DESCRIPTION
Before these changes, a sample android build looked something like this:

<img width="313" alt="screen shot 2017-02-22 at 9 07 31 pm" src="https://cloud.githubusercontent.com/assets/38431/23245706/6cb246e8-f943-11e6-9df9-281a7a55b0b7.png">

There's no indication where that find error came from, just wait it failed to find. With these change, it turns into:

<img width="471" alt="screen shot 2017-02-22 at 9 09 04 pm" src="https://cloud.githubusercontent.com/assets/38431/23245712/8acca650-f943-11e6-98cd-334581296904.png">

We've now got a file and line number from which the find command was executed, but nothing else changed. If we pass `--color_warnings`, the warnings and errors are even more visible:

<img width="507" alt="screen shot 2017-02-22 at 9 10 01 pm" src="https://cloud.githubusercontent.com/assets/38431/23245737/bc58f926-f943-11e6-8141-f0e7d0173e65.png">

They're also in a standard `<location>: (warning|error): <msg>` format similar to clang's output. This helps scripts like our [warn.py](https://android.googlesource.com/platform/build/+/master/tools/warn.py) that search the build logs looking for warning messages.

The second commit here just pipes a location object through HandleFind/RunFind, then it uses the new log macros from the first change:

---

Add `--color_warnings` to make warnings/errors like clang

This adds new `(WARN|KATI_WARN|ERROR)_LOC` log macro variants that take a location as the first argument, and will prefix that location information to the warning/error lines.

When `--color_warnings` is enabled, it reformats them to have a standard warning:/error: infix, and adds colors in order to match the warnings/errors produced by clang.