### PR TITLE
More stable incremental build times - not regenerating in some important cases.

### DIFF
--- a/regen.cc
+++ b/regen.cc
@@ -208,11 +208,15 @@ class StampChecker {
           printf("env %s: dirty (%s => %.*s)\n",
                  s.c_str(), s2.c_str(), SPF(val));
         } else {
-          fprintf(stderr, "Environment variable %s was modified (%s => %.*s), "
-                  "regenerating...\n",
-                  s.c_str(), s2.c_str(), SPF(val));
+          fprintf(stderr, "Environment variable %s was modified (%s => %.*s), ",
+                 s.c_str(), s2.c_str(), SPF(val));
         }
-        RETURN_TRUE;
+        if (s == "TMPDIR") {
+          fprintf(stderr, "ignoring changed TMPDIR\n");
+        } else {
+          fprintf(stderr, "regenerating...\n");
+          RETURN_TRUE;
+        }
       } else if (g_flags.dump_kati_stamp) {
         printf("env %s: clean (%.*s)\n", s.c_str(), SPF(val));
       }
@@ -406,14 +410,24 @@ class StampChecker {
     RunCommand(sr->shell, sr->shellflag, sr->cmd, RedirectStderr::DEV_NULL, &result);
     FormatForCommandSubstitution(&result);
     if (sr->result != result) {
-      if (g_flags.dump_kati_stamp) {
-        printf("shell %s: dirty\n", sr->cmd.c_str());
-      } else {
-        *err = StringPrintf("$(shell %s) was changed, regenerating...\n",
-                            sr->cmd.c_str());
-        //*err += StringPrintf("%s => %s\n", expected.c_str(), result.c_str());
+      string previous_result_sorted = SortWordsInString(sr->result);
+      string current_result_sorted  = SortWordsInString(result);
+      printf("Fallback to sorted comparison for %s\n", sr->cmd.c_str());
+
+      // Some shell commands which use unemulated find can return results 
+      // in different orders depending on the filesystem
+      if (previous_result_sorted != current_result_sorted) { 
+        if (g_flags.dump_kati_stamp) {
+          printf("shell %s: dirty\n", sr->cmd.c_str());
+        } else {
+          *err = StringPrintf("$(shell %s) was changed, regenerating...\n",
+                              sr->cmd.c_str());
+          //*err += StringPrintf("%s => %s\n", expected.c_str(), result.c_str());
+        }
+        return true;
+      } else if (g_flags.regen_debug) {
+        printf("shell %s: clean after sort (rerun)\n", sr->cmd.c_str());
       }
-      return true;
     } else if (g_flags.regen_debug) {
       printf("shell %s: clean (rerun)\n", sr->cmd.c_str());
     }


### PR DESCRIPTION
There are 2 features of this change which are important for my
Android builds and I know that they are important to some other users.
Both aspects are aimed at not regenerating the ninja file needlessly
when one is doing an incremental build.

1) Ignore the contents of the TMPDIR environment variable when calculating
the kati stamp:

TMPDIR has to change sometimes between my builds for various complicated
reasons but I think these also apply to other people who are doing
distributed builds. The result is that the ninja file is regenerated
needlessly. I cannot think of a reason why it *should* be included
therefore it seems reasonable to remove it from consideration.

2) Sort the results of the output from the "find" command.

Filesystems do not all guarantee that 2 successive invocations of find
will return results in the same order. It therefore makes sense to sort
the results.  This patch attempts to sort only if the comparison of 2
file lists fails without it. Therefore the penalty of sorting is only paid
on filesystems which do not return results in the same order every time.
In this way we avoid regenerating the ninja file at times when there is
no relevant reason to do so.