### PR TITLE
Ignore EACCES during find emulator opendir

### DIFF
--- a/find.cc
+++ b/find.cc
@@ -918,7 +918,7 @@ class FindEmulatorImpl : public FindEmulator {
   DirentNode* ConstructDirectoryTree(const string& path) {
     DIR* dir = opendir(path.empty() ? "." : path.c_str());
     if (!dir) {
-      if (errno == ENOENT) {
+      if (errno == ENOENT || errno == EACCES) {
         LOG("opendir failed: %s", path.c_str());
         return NULL;
       } else {


### PR DESCRIPTION
In addition to the race conditions that led me to whitelist ENOENT when
we're initializing the find emulator, also whitelist EACCES. The
reported usecase was when two users are using the same source directory,
but compiling into two out directories under the same source directory.
The permissions were set up so that they didn't have access to each
others out directories, so kati would get permission denied errors.

Test: mkdir -p out2/a; sudo chown nobody:nobody out2/a; <run>