### PR TITLE
Add --werror_find_emulator, --werror_overriding_commands

### DIFF
--- a/dep.cc
+++ b/dep.cc
@@ -162,12 +162,18 @@ struct RuleMerger {
 
     if (primary_rule && !r->cmds.empty() &&
         !IsSuffixRule(output) && !r->is_double_colon) {
-      WARN_LOC(r->cmd_loc(),
-               "warning: overriding commands for target `%s'",
-               output.c_str());
-      WARN_LOC(primary_rule->cmd_loc(),
-               "warning: ignoring old commands for target `%s'",
-               output.c_str());
+      if (g_flags.werror_overriding_commands) {
+        ERROR_LOC(r->cmd_loc(),
+                  "*** overriding commands for target `%s', previously defined at %s:%d",
+                  output.c_str(), LOCF(primary_rule->cmd_loc()));
+      } else {
+        WARN_LOC(r->cmd_loc(),
+                 "warning: overriding commands for target `%s'",
+                 output.c_str());
+        WARN_LOC(primary_rule->cmd_loc(),
+                 "warning: ignoring old commands for target `%s'",
+                 output.c_str());
+      }
       primary_rule = r;
     }
     if (!primary_rule && !r->cmds.empty()) {

--- a/flags.cc
+++ b/flags.cc
@@ -99,6 +99,10 @@ void Flags::Parse(int argc, char** argv) {
       detect_depfiles = true;
     } else if (!strcmp(arg, "--color_warnings")) {
       color_warnings = true;
+    } else if (!strcmp(arg, "--werror_find_emulator")) {
+      werror_find_emulator = true;
+    } else if (!strcmp(arg, "--werror_overriding_commands")) {
+      werror_overriding_commands = true;
     } else if (ParseCommandLineOptionWithArg(
         "-j", argv, &i, &num_jobs_str)) {
       num_jobs = strtol(num_jobs_str, NULL, 10);

--- a/flags.h
+++ b/flags.h
@@ -40,6 +40,8 @@ struct Flags {
   bool regen_ignoring_kati_binary;
   bool use_find_emulator;
   bool color_warnings;
+  bool werror_find_emulator;
+  bool werror_overriding_commands;
   const char* goma_dir;
   const char* ignore_dirty_pattern;
   const char* no_ignore_dirty_pattern;

--- a/testcase/werror_find_emulator.sh
+++ b/testcase/werror_find_emulator.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+#
+# Copyright 2017 Google Inc. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -u
+
+mk="$@"
+
+cat <<EOF > Makefile
+FOO := \$(shell find does/not/exist -name '*.txt')
+all:
+EOF
+
+if echo "${mk}" | grep -qv "kati"; then
+  # Make doesn't use find emulator, or support --werror_find_emulator, so write
+  # expected output.
+  echo 'find: "does/not/exist": No such file or directory'
+  echo 'Nothing to be done for "all".'
+  echo 'Clean exit'
+else
+  ${mk} --use_find_emulator 2>&1 && echo "Clean exit"
+fi
+
+if echo "${mk}" | grep -qv "kati"; then
+  echo 'find: "does/not/exist": No such file or directory'
+else
+  ${mk} --use_find_emulator --werror_find_emulator 2>&1 && echo "Clean exit"
+fi

--- a/testcase/werror_overriding_commands.sh
+++ b/testcase/werror_overriding_commands.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+#
+# Copyright 2017 Google Inc. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -u
+
+mk="$@"
+
+cat <<EOF > Makefile
+test: foo
+foo:
+	@echo "FAIL"
+foo:
+	@echo "PASS"
+EOF
+
+if echo "${mk}" | grep -qv "kati"; then
+  # Make doesn't use find emulator, or support --werror_find_emulator, so write
+  # expected output.
+  echo 'Makefile:5: warning: overriding commands for target "foo"'
+  echo 'Makefile:3: warning: ignoring old commands for target "foo"'
+  echo 'PASS'
+  echo 'Clean exit'
+else
+  ${mk} 2>&1 && echo "Clean exit"
+fi
+
+if echo "${mk}" | grep -qv "kati"; then
+  echo 'Makefile:5: *** overriding commands for target "foo", previously defined at Makefile:3'
+else
+  ${mk} --werror_overriding_commands 2>&1 && echo "Clean exit"
+fi


### PR DESCRIPTION
For Android builds, we'd like to start removing some of the default warnings and turn them into errors so that they can't come back.

For find emulator, we could attempt to check for errors, or silence every find command in the tree, but that doesn't particularly scale, especially when new code gets added with warnings. We've gone through and fixed many of these, but they keep coming back, so add ```--werror_find_emulator``` so that when we fix them all we can prevent them from coming back.

Overriding commands is similar -- we really don't want multiple rules defining a single output file. In ninja we've turned on ```-w dupbuild=err```, but if the paths happen to be identical the makefile overriding logic kicks in first and presents a warning instead of an error. So add ```--werror_overriding_commands``` in order to turn the make warning into an error.