### PR TITLE
Support Ninja implicit outputs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,18 @@
 language: cpp
 
+dist: trusty
+sudo: required
+
 compiler:
   - clang
 
 cache: apt
 
 before_script:
-  - sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu/ trusty main universe"
   - sudo apt-get update -qq
-  - sudo apt-get install -y libstdc++-4.8-dev clang-3.5 ninja-build realpath
+  - sudo apt-get install -y realpath
+  - wget https://github.com/ninja-build/ninja/releases/download/v1.7.2/ninja-linux.zip
+  - unzip ninja-linux.zip -d ~/bin
 
 script:
   - make -j4 ckati ckati_tests

--- a/dep.cc
+++ b/dep.cc
@@ -239,6 +239,7 @@ DepNode::DepNode(Symbol o, bool p, bool r)
       is_restat(r),
       rule_vars(NULL),
       depfile_var(NULL),
+      implicit_outputs_var(NULL),
       ninja_pool_var(NULL),
       output_pattern(Symbol::IsUninitialized()) {
   g_dep_node_pool->push_back(this);
@@ -254,6 +255,7 @@ class DepBuilder {
         implicit_rules_(new RuleTrie()),
         first_rule_(Symbol::IsUninitialized{}),
         depfile_var_name_(Intern(".KATI_DEPFILE")),
+        implicit_outputs_var_name_(Intern(".KATI_IMPLICIT_OUTPUTS")),
         ninja_pool_var_name_(Intern(".KATI_NINJA_POOL")) {
     ScopedTimeReporter tr("make dep (populate)");
     PopulateRules(rules);
@@ -616,6 +618,8 @@ class DepBuilder {
 
         if (name == depfile_var_name_) {
           n->depfile_var = new_var;
+        } else if (name == implicit_outputs_var_name_) {
+          n->implicit_outputs_var = new_var;
         } else if (name == ninja_pool_var_name_) {
           n->ninja_pool_var = new_var;
         } else {
@@ -662,6 +666,7 @@ class DepBuilder {
   unordered_set<Symbol> phony_;
   unordered_set<Symbol> restat_;
   Symbol depfile_var_name_;
+  Symbol implicit_outputs_var_name_;
   Symbol ninja_pool_var_name_;
 };
 

--- a/dep.h
+++ b/dep.h
@@ -45,6 +45,7 @@ struct DepNode {
   vector<Symbol> actual_order_only_inputs;
   Vars* rule_vars;
   Var* depfile_var;
+  Var* implicit_outputs_var;
   Var* ninja_pool_var;
   Symbol output_pattern;
   Loc loc;

--- a/ninja.cc
+++ b/ninja.cc
@@ -546,7 +546,21 @@ class NinjaGenerator {
                  bool use_local_pool, ostringstream* o) {
     const DepNode* node = nn->node;
     string target = EscapeBuildTarget(node->output);
-    *o << "build " << target << ": " << rule_name;
+    *o << "build " << target;
+    if (node->implicit_outputs_var) {
+      string implicit_outputs;
+      node->implicit_outputs_var->Eval(ev_, &implicit_outputs);
+
+      bool first = true;
+      for (StringPiece output : WordScanner(implicit_outputs)) {
+        if (first) {
+          *o << " |";
+          first = false;
+        }
+        *o << " " << EscapeNinja(output.as_string()).c_str();
+      }
+    }
+    *o << ": " << rule_name;
     vector<Symbol> order_onlys;
     if (node->is_phony) {
       *o << " _kati_always_build_";

--- a/testcase/ninja_implicit_outputs.sh
+++ b/testcase/ninja_implicit_outputs.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+#
+# Copyright 2015 Google Inc. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+mk="$@"
+
+cat <<EOF >Makefile
+all: a b
+
+a b:
+	touch A
+	echo 1 >>A
+c: .KATI_IMPLICIT_OUTPUTS := d
+c:
+	touch C
+	echo 1 >>C
+EOF
+
+$@ -j1 all c
+if [ -e ninja.sh ]; then ./ninja.sh -j1 all d; fi
+
+echo "A:"
+cat A
+echo "C":
+cat C


### PR DESCRIPTION
Add .KATI_IMPLICIT_OUTPUTS target-specific variable to add extra implicit outputs to the build line in the ninja file. This doesn't actually affect the node graph within Kati, but combined with --gen_all_targets should be usable.

This allows us to properly define the build graph in ninja when one rule creates multiple files. There are a number of ways that people attempt to do this in make, all of which have problems:

```make
a b:
	touch a b
```

Define multiple outputs with the same rule. This looks correct to most people, but actually runs the rule multiple times -- once for every output file. Most of the time this works, but runs into very strange concurrency issues when the two rules happen to run at the same time.

```make
a:
	touch a b
```

Only define one of the files in the graph. Then users need to depend on a file that they don't use, and the unlisted file won't be noticed if it's updated separately (or even removed).

```make
b: a
a:
	touch a b
```

Define dependencies between the multiple files. This doesn't actually know how to update `b` if `b` is older than `a`, or doesn't exist.

```make
b: a
	touch b
a:
	touch a b
```

A variant of the previous approach, which can "fix" the timestamp if the original rule happened to create `b` before `a`. This can be even more dangerous, since it may create / update `b` improperly.

But since ninja supports a graph where there can be multiple outputs from a single edge, with this patch we can write:

```make
a: .KATI_IMPLICIT_OUTPUTS := b
a:
	touch a b
```

which translates to:

```ninja
rule rule1
  command = touch a b
build a | b: rule1
```

This ninja will allow users to depend on either `a` or `b`, and the rule will be run (once) as appropriate.