### PR TITLE
Include implicit outputs in the DepNode graph

### DIFF
--- a/dep.h
+++ b/dep.h
@@ -41,11 +41,11 @@ struct DepNode {
   bool is_default_target;
   bool is_phony;
   bool is_restat;
+  vector<Symbol> implicit_outputs;
   vector<Symbol> actual_inputs;
   vector<Symbol> actual_order_only_inputs;
   Vars* rule_vars;
   Var* depfile_var;
-  Var* implicit_outputs_var;
   Var* ninja_pool_var;
   Symbol output_pattern;
   Loc loc;

--- a/ninja.cc
+++ b/ninja.cc
@@ -547,17 +547,10 @@ class NinjaGenerator {
     const DepNode* node = nn->node;
     string target = EscapeBuildTarget(node->output);
     *o << "build " << target;
-    if (node->implicit_outputs_var) {
-      string implicit_outputs;
-      node->implicit_outputs_var->Eval(ev_, &implicit_outputs);
-
-      bool first = true;
-      for (StringPiece output : WordScanner(implicit_outputs)) {
-        if (first) {
-          *o << " |";
-          first = false;
-        }
-        *o << " " << EscapeNinja(output.as_string()).c_str();
+    if (!node->implicit_outputs.empty()) {
+      *o << " |";
+      for (Symbol output : node->implicit_outputs) {
+        *o << " " << EscapeBuildTarget(output);
       }
     }
     *o << ": " << rule_name;

--- a/testcase/ninja_implicit_output_var.sh
+++ b/testcase/ninja_implicit_output_var.sh
@@ -19,24 +19,17 @@ set -e
 mk="$@"
 
 cat <<EOF >Makefile
-all: a b
+all: a
 
-a b:
-	touch A
-	echo 1 >>A
-d: a
-c: .KATI_IMPLICIT_OUTPUTS := d
-c:
-	touch C
-	echo 1 >>C
-
-c d: b
+a:
+	if ! [ -z "\$(VAR)" ]; then echo \$(VAR); fi
+a: .KATI_IMPLICIT_OUTPUTS := b
+b: VAR := OK
 EOF
 
-${mk} -j1 all d c
-if [ -e ninja.sh ]; then ./ninja.sh -j1 -w dupbuild=err all d; fi
-
-echo "A:"
-cat A
-echo "C":
-cat C
+${mk} -j1
+if [ -e ninja.sh ]; then
+  ./ninja.sh -j1 -w dupbuild=err;
+else
+  echo OK
+fi


### PR DESCRIPTION
The last patch was good enough for simple use cases, but if a dependency was added to the implicit output, Kati would create a phony rule in addition to the implicit output.

This patch will cause the rules to be combined into a single DepNode, combining any variables and dependencies.