### PR TITLE
Bionic support and build system updates

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -20,11 +20,6 @@ cc_defaults {
         "-Werror",
         "-DNOLOG",
     ],
-    target: {
-        linux: {
-            host_ldlibs: ["-lrt", "-lpthread"],
-        },
-    },
     tidy_checks: [
         "-google-global-names-in-headers",
         "-google-build-using-namespace",

--- a/exec.cc
+++ b/exec.cc
@@ -18,6 +18,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <sys/wait.h>
 
 #include <memory>
 #include <unordered_map>

--- a/runtest.rb
+++ b/runtest.rb
@@ -177,6 +177,8 @@ def normalize_kati_log(output)
   # Normalization for "include foo" with Go kati.
   output.gsub!(/(: )open (\S+): n(o such file or directory)\nNOTE:.*/,
                "\\1\\2: N\\3")
+  # Bionic libc has different error messages than glibc
+  output.gsub!(/Too many symbolic links encountered/, 'Too many levels of symbolic links')
   output
 end
 


### PR DESCRIPTION
We no longer need to specify -lrt or -lpthread, since they're now included in the default library set. Also add some fixes for compiling/running using bionic as a libc, which is an experimental option in Soong.