### PR TITLE
Add deprecated / obsolete variable support

### DIFF
--- a/expr.cc
+++ b/expr.cc
@@ -134,6 +134,7 @@ class SymRef : public Value {
 
   virtual void Eval(Evaluator* ev, string* s) const override {
     Var* v = ev->LookupVar(name_);
+    v->Used(ev, name_);
     v->Eval(ev, s);
   }
 
@@ -158,7 +159,9 @@ class VarRef : public Value {
     ev->IncrementEvalDepth();
     const string&& name = name_->Eval(ev);
     ev->DecrementEvalDepth();
-    Var* v = ev->LookupVar(Intern(name));
+    Symbol sym = Intern(name);
+    Var* v = ev->LookupVar(sym);
+    v->Used(ev, sym);
     v->Eval(ev, s);
   }
 
@@ -184,10 +187,12 @@ class VarSubst : public Value {
   virtual void Eval(Evaluator* ev, string* s) const override {
     ev->IncrementEvalDepth();
     const string&& name = name_->Eval(ev);
-    Var* v = ev->LookupVar(Intern(name));
+    Symbol sym = Intern(name);
+    Var* v = ev->LookupVar(sym);
     const string&& pat_str = pat_->Eval(ev);
     const string&& subst = subst_->Eval(ev);
     ev->DecrementEvalDepth();
+    v->Used(ev, sym);
     const string&& value = v->Eval(ev);
     WordWriter ww(s);
     Pattern pat(pat_str);

--- a/testcase/deprecated_var.mk
+++ b/testcase/deprecated_var.mk
@@ -1,0 +1,70 @@
+# TODO(go): not implemented
+
+
+A := test
+$(KATI_deprecated_var A B C D)
+
+# Writing to an undefined deprecated variable
+B := test
+ifndef KATI
+$(info Makefile:8: B has been deprecated.)
+endif
+
+# Reading from deprecated variables (set before/after/never the deprecation func)
+# Writing to an undefined deprecated variable
+D := $(A)$(B)$(C)
+ifndef KATI
+$(info Makefile:15: A has been deprecated.)
+$(info Makefile:15: B has been deprecated.)
+$(info Makefile:15: C has been deprecated.)
+$(info Makefile:15: D has been deprecated.)
+endif
+
+# Writing to a reset deprecated variable
+D += test
+ifndef KATI
+$(info Makefile:24: D has been deprecated.)
+endif
+
+# Using a custom message
+$(KATI_deprecated_var E,Use X instead)
+E = $(C)
+ifndef KATI
+$(info Makefile:31: E has been deprecated. Use X instead.)
+endif
+
+# Expanding a recursive variable with an embedded deprecated variable
+$(E)
+ifndef KATI
+$(info Makefile:37: E has been deprecated. Use X instead.)
+$(info Makefile:37: C has been deprecated.)
+endif
+
+# All of the previous variable references have been basic SymRefs, now check VarRefs
+F = E
+G := $($(F))
+ifndef KATI
+$(info Makefile:45: E has been deprecated. Use X instead.)
+$(info Makefile:45: C has been deprecated.)
+endif
+
+# And check VarSubst
+G := $(C:%.o=%.c)
+ifndef KATI
+$(info Makefile:52: C has been deprecated.)
+endif
+
+# Deprecated variable used in a rule-specific variable
+test: A := $(E)
+ifndef KATI
+$(info Makefile:58: E has been deprecated. Use X instead.)
+$(info Makefile:58: C has been deprecated.)
+# A hides the global A variable, so is not considered deprecated.
+endif
+
+# Deprecated variable used in a rule
+test:
+	echo $(C)Done
+ifndef KATI
+$(info Makefile:67: C has been deprecated.)
+endif

--- a/testcase/err_deprecated_var_already_deprecated.mk
+++ b/testcase/err_deprecated_var_already_deprecated.mk
@@ -1,0 +1,4 @@
+# TODO(go): not implemented
+
+$(KATI_deprecated_var A)
+$(KATI_deprecated_var A)$(or $(KATI),$(error Cannot call KATI_deprecated_var on already deprecated variable: A))

--- a/testcase/err_deprecated_var_already_obsolete.mk
+++ b/testcase/err_deprecated_var_already_obsolete.mk
@@ -1,0 +1,4 @@
+# TODO(go): not implemented
+
+$(KATI_obsolete_var A)
+$(KATI_deprecated_var A)$(or $(KATI),$(error Cannot call KATI_deprecated_var on already obsolete variable: A))

--- a/testcase/err_obsolete_var.mk
+++ b/testcase/err_obsolete_var.mk
@@ -1,0 +1,6 @@
+# TODO(go): not implemented
+#
+# We go into a lot more cases in deprecated_var.mk, and hope that if deprecated works, obsolete does too.
+
+$(KATI_obsolete_var A)
+$(A) $(or $(KATI),$(error A is obsolete))

--- a/testcase/err_obsolete_var_already_deprecated.mk
+++ b/testcase/err_obsolete_var_already_deprecated.mk
@@ -1,0 +1,4 @@
+# TODO(go): not implemented
+
+$(KATI_deprecated_var A)
+$(KATI_obsolete_var A)$(or $(KATI),$(error Cannot call KATI_obsolete_var on already deprecated variable: A))

--- a/testcase/err_obsolete_var_already_obsolete.mk
+++ b/testcase/err_obsolete_var_already_obsolete.mk
@@ -1,0 +1,4 @@
+# TODO(go): not implemented
+
+$(KATI_obsolete_var A)
+$(KATI_obsolete_var A)$(or $(KATI),$(error Cannot call KATI_obsolete_var on already obsolete variable: A))

--- a/testcase/err_obsolete_var_assign.mk
+++ b/testcase/err_obsolete_var_assign.mk
@@ -1,0 +1,4 @@
+# TODO(go): not implemented
+
+$(KATI_obsolete_var A)
+A := $(or $(KATI),$(error A is obsolete))

--- a/testcase/err_obsolete_var_msg.mk
+++ b/testcase/err_obsolete_var_msg.mk
@@ -1,0 +1,4 @@
+# TODO(go): not implemented
+
+$(KATI_obsolete_var A,Use Y instead)
+$(A) $(or $(KATI),$(error A is obsolete. Use Y instead))

--- a/testcase/err_obsolete_var_varref.mk
+++ b/testcase/err_obsolete_var_varref.mk
@@ -1,0 +1,5 @@
+# TODO(go): not implemented
+
+$(KATI_obsolete_var A)
+B := A
+$($(B)) $(or $(KATI),$(error A is obsolete))

--- a/testcase/err_obsolete_var_varsubst.mk
+++ b/testcase/err_obsolete_var_varsubst.mk
@@ -1,0 +1,4 @@
+# TODO(go): not implemented
+
+$(KATI_obsolete_var A)
+$(A:%.o=%.c) $(or $(KATI),$(error A is obsolete))

--- a/var.cc
+++ b/var.cc
@@ -16,6 +16,7 @@
 
 #include "var.h"
 
+#include "eval.h"
 #include "expr.h"
 #include "log.h"
 
@@ -37,7 +38,7 @@ const char* GetOriginStr(VarOrigin origin) {
   return "*** broken origin ***";
 }
 
-Var::Var() : readonly_(false) {
+Var::Var() : readonly_(false), message_(), error_(false) {
 }
 
 Var::~Var() {


### PR DESCRIPTION
By calling the custom KATI_deprecated_var / KATI_obsolete_var functions, variables may be marked as deprecated or obsolete.

When accessed or assigned, deprecated variables will print a warning.

When accessed or assigned, obsolete variables will print an error and stop.

Variables do not need to be set before calling the functions, and will persist the deprecation warning through a reassignment. This way we can easily mark variables that are sometimes passed via the environment as deprecated.