### PR TITLE
Stack usage debugging tools

### DIFF
--- a/eval.h
+++ b/eval.h
@@ -86,6 +86,15 @@ class Evaluator {
   string GetShellFlag();
   string GetShellAndFlag();
 
+  void CheckStack() {
+    void* addr = __builtin_frame_address(0);
+    if (__builtin_expect(addr < lowest_stack_ && addr >= stack_addr_, 0)) {
+      lowest_stack_ = addr;
+      lowest_loc_ = loc_;
+    }
+  }
+  void DumpStackStats() const;
+
  private:
   Var* EvalRHS(Symbol lhs,
                Value* rhs,
@@ -118,6 +127,11 @@ class Evaluator {
 
   Symbol posix_sym_;
   bool is_posix_;
+
+  void* stack_addr_;
+  size_t stack_size_;
+  void* lowest_stack_;
+  Loc lowest_loc_;
 
   static unordered_set<Symbol> used_undefined_vars_;
 

--- a/expr.cc
+++ b/expr.cc
@@ -52,7 +52,8 @@ class Literal : public Value {
 
   StringPiece val() const { return s_; }
 
-  virtual void Eval(Evaluator*, string* s) const override {
+  virtual void Eval(Evaluator* ev, string* s) const override {
+    ev->CheckStack();
     s->append(s_.begin(), s_.end());
   }
 
@@ -79,6 +80,7 @@ class Expr : public Value {
   void AddValue(Value* v) { vals_.push_back(v); }
 
   virtual void Eval(Evaluator* ev, string* s) const override {
+    ev->CheckStack();
     for (Value* v : vals_) {
       v->Eval(ev, s);
     }
@@ -119,6 +121,7 @@ class SymRef : public Value {
   virtual ~SymRef() {}
 
   virtual void Eval(Evaluator* ev, string* s) const override {
+    ev->CheckStack();
     Var* v = ev->LookupVar(name_);
     v->Used(ev, name_);
     v->Eval(ev, s);
@@ -138,6 +141,7 @@ class VarRef : public Value {
   virtual ~VarRef() { delete name_; }
 
   virtual void Eval(Evaluator* ev, string* s) const override {
+    ev->CheckStack();
     ev->IncrementEvalDepth();
     const string&& name = name_->Eval(ev);
     ev->DecrementEvalDepth();
@@ -166,6 +170,7 @@ class VarSubst : public Value {
   }
 
   virtual void Eval(Evaluator* ev, string* s) const override {
+    ev->CheckStack();
     ev->IncrementEvalDepth();
     const string&& name = name_->Eval(ev);
     Symbol sym = Intern(name);
@@ -205,6 +210,7 @@ class Func : public Value {
   }
 
   virtual void Eval(Evaluator* ev, string* s) const override {
+    ev->CheckStack();
     LOG("Invoke func %s(%s)", name(), JoinValues(args_, ",").c_str());
     ev->IncrementEvalDepth();
     fi_->func(args_, ev, s);

--- a/func.cc
+++ b/func.cc
@@ -462,6 +462,7 @@ void ValueFunc(const vector<Value*>& args, Evaluator* ev, string* s) {
 void EvalFunc(const vector<Value*>& args, Evaluator* ev, string*) {
   // TODO: eval leaks everything... for now.
   // const string text = args[0]->Eval(ev);
+  ev->CheckStack();
   string* text = new string;
   args[0]->Eval(ev, text);
   if (ev->avoid_io()) {
@@ -595,6 +596,7 @@ void CallFunc(const vector<Value*>& args, Evaluator* ev, string* s) {
       Intern("0"), Intern("1"), Intern("2"), Intern("3"), Intern("4"),
       Intern("5"), Intern("6"), Intern("7"), Intern("8"), Intern("9")};
 
+  ev->CheckStack();
   const string&& func_name_buf = args[0]->Eval(ev);
   const StringPiece func_name = TrimSpace(func_name_buf);
   Var* func = ev->LookupVar(Intern(func_name));

--- a/main.cc
+++ b/main.cc
@@ -195,6 +195,7 @@ static int Run(const vector<Symbol>& targets,
   if (g_flags.generate_ninja) {
     ScopedTimeReporter tr("generate ninja time");
     GenerateNinja(nodes, ev, orig_args, start_time);
+    ev->DumpStackStats();
     return 0;
   }
 
@@ -215,6 +216,8 @@ static int Run(const vector<Symbol>& targets,
     ScopedTimeReporter tr("exec time");
     Exec(nodes, ev);
   }
+
+  ev->DumpStackStats();
 
   for (Stmt* stmt : bootstrap_asts)
     delete stmt;

--- a/main.cc
+++ b/main.cc
@@ -15,6 +15,7 @@
 // +build ignore
 
 #include <limits.h>
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -46,7 +47,7 @@
 
 // We know that there are leaks in Kati. Turn off LeakSanitizer by default.
 extern "C" const char* __asan_default_options() {
-  return "detect_leaks=0";
+  return "detect_leaks=0:allow_user_segv_handler=1";
 }
 
 static void Init() {
@@ -121,6 +122,97 @@ static void SetVar(StringPiece l, VarOrigin origin) {
 
 extern "C" char** environ;
 
+class SegfaultHandler {
+ public:
+  explicit SegfaultHandler(Evaluator* ev);
+  ~SegfaultHandler();
+
+  void handle(int, siginfo_t*, void*);
+
+ private:
+  static SegfaultHandler* global_handler;
+
+  void dumpstr(const char* s) const {
+    (void)write(STDERR_FILENO, s, strlen(s));
+  }
+  void dumpint(int i) const {
+    char buf[11];
+    char* ptr = buf + sizeof(buf) - 1;
+
+    if (i < 0) {
+      i = -i;
+      dumpstr("-");
+    } else if (i == 0) {
+      dumpstr("0");
+      return;
+    }
+
+    *ptr = '\0';
+    while (ptr > buf && i > 0) {
+      *--ptr = '0' + (i % 10);
+      i = i / 10;
+    }
+
+    dumpstr(ptr);
+  }
+
+  Evaluator* ev_;
+
+  struct sigaction orig_action_;
+  struct sigaction new_action_;
+};
+
+SegfaultHandler* SegfaultHandler::global_handler = nullptr;
+
+SegfaultHandler::SegfaultHandler(Evaluator* ev) : ev_(ev) {
+  CHECK(global_handler == nullptr);
+  global_handler = this;
+
+  // Construct an alternate stack, so that we can handle stack overflows.
+  stack_t ss;
+  ss.ss_sp = malloc(SIGSTKSZ * 2);
+  CHECK(ss.ss_sp != nullptr);
+  ss.ss_size = SIGSTKSZ * 2;
+  ss.ss_flags = 0;
+  if (sigaltstack(&ss, nullptr) == -1) {
+    PERROR("sigaltstack");
+  }
+
+  // Register our segfault handler using the alternate stack, falling
+  // back to the default handler.
+  sigemptyset(&new_action_.sa_mask);
+  new_action_.sa_flags = SA_ONSTACK | SA_SIGINFO | SA_RESETHAND;
+  new_action_.sa_sigaction = [](int sig, siginfo_t* info, void* context) {
+    if (global_handler != nullptr) {
+      global_handler->handle(sig, info, context);
+    }
+
+    raise(SIGSEGV);
+  };
+  sigaction(SIGSEGV, &new_action_, &orig_action_);
+}
+
+void SegfaultHandler::handle(int sig, siginfo_t* info, void* context) {
+  // Avoid fprintf in case it allocates or tries to do anything else that may
+  // hang.
+  dumpstr("*kati*: Segmentation fault, last evaluated line was ");
+  dumpstr(ev_->loc().filename);
+  dumpstr(":");
+  dumpint(ev_->loc().lineno);
+  dumpstr("\n");
+
+  // Run the original handler, in case we've been preloaded with libSegFault
+  // or similar.
+  if (orig_action_.sa_sigaction != nullptr) {
+    orig_action_.sa_sigaction(sig, info, context);
+  }
+}
+
+SegfaultHandler::~SegfaultHandler() {
+  sigaction(SIGSEGV, &orig_action_, nullptr);
+  global_handler = nullptr;
+}
+
 static int Run(const vector<Symbol>& targets,
                const vector<StringPiece>& cl_vars,
                const string& orig_args) {
@@ -149,14 +241,15 @@ static int Run(const vector<Symbol>& targets,
   for (char** p = environ; *p; p++) {
     SetVar(*p, VarOrigin::ENVIRONMENT);
   }
-  Evaluator* ev = new Evaluator();
+  unique_ptr<Evaluator> ev(new Evaluator());
+  SegfaultHandler segfault(ev.get());
 
   vector<Stmt*> bootstrap_asts;
   ReadBootstrapMakefile(targets, &bootstrap_asts);
   ev->set_is_bootstrap(true);
   for (Stmt* stmt : bootstrap_asts) {
     LOG("%s", stmt->DebugString().c_str());
-    stmt->Eval(ev);
+    stmt->Eval(ev.get());
   }
   ev->set_is_bootstrap(false);
 
@@ -165,7 +258,7 @@ static int Run(const vector<Symbol>& targets,
     vector<Stmt*> asts;
     Parse(Intern(l).str(), Loc("*bootstrap*", 0), &asts);
     CHECK(asts.size() == 1);
-    asts[0]->Eval(ev);
+    asts[0]->Eval(ev.get());
   }
   ev->set_is_commandline(false);
 
@@ -174,7 +267,7 @@ static int Run(const vector<Symbol>& targets,
     Makefile* mk = cache_mgr->ReadMakefile(g_flags.makefile);
     for (Stmt* stmt : mk->stmts()) {
       LOG("%s", stmt->DebugString().c_str());
-      stmt->Eval(ev);
+      stmt->Eval(ev.get());
     }
   }
 
@@ -186,7 +279,7 @@ static int Run(const vector<Symbol>& targets,
   vector<DepNode*> nodes;
   {
     ScopedTimeReporter tr("make dep time");
-    MakeDep(ev, ev->rules(), ev->rule_vars(), targets, &nodes);
+    MakeDep(ev.get(), ev->rules(), ev->rule_vars(), targets, &nodes);
   }
 
   if (g_flags.is_syntax_check_only)
@@ -194,7 +287,7 @@ static int Run(const vector<Symbol>& targets,
 
   if (g_flags.generate_ninja) {
     ScopedTimeReporter tr("generate ninja time");
-    GenerateNinja(nodes, ev, orig_args, start_time);
+    GenerateNinja(nodes, ev.get(), orig_args, start_time);
     ev->DumpStackStats();
     return 0;
   }
@@ -203,7 +296,7 @@ static int Run(const vector<Symbol>& targets,
     const Symbol name = p.first;
     if (p.second) {
       Var* v = ev->LookupVar(name);
-      const string&& value = v->Eval(ev);
+      const string&& value = v->Eval(ev.get());
       LOG("setenv(%s, %s)", name.c_str(), value.c_str());
       setenv(name.c_str(), value.c_str(), 1);
     } else {
@@ -214,14 +307,13 @@ static int Run(const vector<Symbol>& targets,
 
   {
     ScopedTimeReporter tr("exec time");
-    Exec(nodes, ev);
+    Exec(nodes, ev.get());
   }
 
   ev->DumpStackStats();
 
   for (Stmt* stmt : bootstrap_asts)
     delete stmt;
-  delete ev;
   delete cache_mgr;
 
   return 0;

--- a/testcase/segfault_stack_overflow.sh
+++ b/testcase/segfault_stack_overflow.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+# Copyright 2017 Google Inc. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -u
+
+mk="$@"
+
+cat <<EOF > Makefile
+a = \$(a) \$(a) \$(a) \$(a)
+\$(a)
+EOF
+
+if echo "${mk}" | grep -qv "kati"; then
+  # Make detects this differently
+  echo 'Segmentation fault, last evaluated line was Makefile:2'
+else
+  # runtest.rb strips *kati*: lines, so strip that prefix to test
+  # Grab only *kati* lines, since asan may print a backtrace
+  ${mk} 2>&1 | grep "*kati*" | sed "s/^\*kati\*: //"
+fi

--- a/var.cc
+++ b/var.cc
@@ -59,7 +59,8 @@ SimpleVar::SimpleVar(VarOrigin origin) : origin_(origin) {}
 SimpleVar::SimpleVar(const string& v, VarOrigin origin)
     : v_(v), origin_(origin) {}
 
-void SimpleVar::Eval(Evaluator*, string* s) const {
+void SimpleVar::Eval(Evaluator* ev, string* s) const {
+  ev->CheckStack();
   *s += v_;
 }
 
@@ -82,10 +83,12 @@ RecursiveVar::RecursiveVar(Value* v, VarOrigin origin, StringPiece orig)
     : v_(v), origin_(origin), orig_(orig) {}
 
 void RecursiveVar::Eval(Evaluator* ev, string* s) const {
+  ev->CheckStack();
   v_->Eval(ev, s);
 }
 
-void RecursiveVar::AppendVar(Evaluator*, Value* v) {
+void RecursiveVar::AppendVar(Evaluator* ev, Value* v) {
+  ev->CheckStack();
   v_ = NewExpr3(v_, NewLiteral(" "), v);
 }
 


### PR DESCRIPTION
We've been seeing occasional segmentation faults that appear to be stack overflows, but they've been difficult to track down. These two patches add some debugging tools:

1) Add a stack usage statistic. In functions that could recursively use a lot of stack, record the stack usage and makefile location if it's larger than what we've seen before. Then if --kati_stats is used, we'll print out makefile line using the most stack. This identified two bugs in our makefiles that were using significantly more stack than necessary:

https://android-review.googlesource.com/c/platform/build/+/505717
https://android-review.googlesource.com/c/platform/build/+/505718

```
*kati*: Stack size:    8388608 bytes
*kati*: Max stack use: 3936 bytes at Makefile.ckati:114
```

2) Custom SIGSEGV (Segmentation fault) handler. With this handler, we'll print out the most recently evaluated makefile line before continuing to handle the signal. libSegFault and ASAN can point towards which functions we were in, but knowing that we've been expanding a variable doesn't give enough context to really diagnose the problem. We've also had cases where ASAN has managed to hide the problem.

```
*kati*: Segmentation fault, last evaluated line was Makefile:2
ASAN:DEADLYSIGNAL
=================================================================
==121681==ERROR: AddressSanitizer: stack-overflow on address 0x7ffc607aaff8 (pc 0x55b69d41fe7f bp 0x7ffc607ab870 sp 0x7ffc607ab000 T0)
    #0 0x55b69d41fe7e in __asan_memcpy external/compiler-rt/lib/asan/asan_interceptors.cc:455:3
    #1 0x55b69d4874c5 in Evaluator::CheckStack() build/kati/eval.h:101:19
    #2 0x55b69d4874c5 in SymRef::Eval(Evaluator*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >*) const build/kati/expr.cc:138
    #3 0x55b69d48877d in Expr::Eval(Evaluator*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >*) const build/kati/expr.cc:96:10
    #4 0x55b69d48877d in Expr::Eval(Evaluator*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >*) const build/kati/expr.cc:96:10
    #5 0x55b69d48877d in Expr::Eval(Evaluator*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >*) const build/kati/expr.cc:96:10
    #6 0x55b69d48877d in Expr::Eval(Evaluator*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >*) const build/kati/expr.cc:96:10
    #7 0x55b69d48877d in Expr::Eval(Evaluator*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >*) const build/kati/expr.cc:96:10
    #8 0x55b69d48877d in Expr::Eval(Evaluator*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >*) const build/kati/expr.cc:96:10
    #9 0x55b69d48877d in Expr::Eval(Evaluator*, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >*) const build/kati/expr.cc:96:10
    ...
```