### PR TITLE
Fix list of used environment variables

### DIFF
--- a/eval.h
+++ b/eval.h
@@ -105,6 +105,9 @@ class Evaluator {
 
   Var* LookupVarGlobal(Symbol name);
 
+  // Equivalent to LookupVarInCurrentScope, but doesn't mark as used.
+  Var* PeekVarInCurrentScope(Symbol name);
+
   unordered_map<Symbol, Vars*> rule_vars_;
   vector<const Rule*> rules_;
   unordered_map<Symbol, bool> exports_;

--- a/symtab.cc
+++ b/symtab.cc
@@ -43,6 +43,13 @@ Symbol kShellSym = Symbol(Symbol::IsUninitialized());
 
 Symbol::Symbol(int v) : v_(v) {}
 
+Var* Symbol::PeekGlobalVar() const {
+  if (static_cast<size_t>(v_) >= g_symbol_data.size()) {
+    return kUndefined;
+  }
+  return g_symbol_data[v_].gv;
+}
+
 Var* Symbol::GetGlobalVar() const {
   if (static_cast<size_t>(v_) >= g_symbol_data.size()) {
     g_symbol_data.resize(v_ + 1);

--- a/symtab.h
+++ b/symtab.h
@@ -49,6 +49,7 @@ class Symbol {
 
   bool IsValid() const { return v_ >= 0; }
 
+  Var* PeekGlobalVar() const;
   Var* GetGlobalVar() const;
   void SetGlobalVar(Var* v,
                     bool is_override = false,

--- a/testcase/ninja_regen.sh
+++ b/testcase/ninja_regen.sh
@@ -39,10 +39,12 @@ fi
 
 sleep_if_necessary 1
 cat <<EOF > Makefile
+VAR3 := unused
 all:
 	echo bar
 	echo VAR=\$(VAR)
 	echo VAR2=\$(VAR2)
+	echo VAR3=\$(VAR3)
 	echo wildcard=\$(wildcard *.mk)
 other:
 	echo foo
@@ -70,6 +72,24 @@ ${mk} 2> ${log}
 if [ -e ninja.sh ]; then
   if ! grep regenerating ${log} > /dev/null; then
     echo 'Should be regenerated (env added)'
+  fi
+  ./ninja.sh
+fi
+
+export VAR3=testing
+${mk} 2> ${log}
+if [ -e ninja.sh ]; then
+  if grep regenerating ${log} >/dev/null; then
+    echo 'Should not regenerate (unused env added)'
+  fi
+  ./ninja.sh
+fi
+
+export VAR3=test2
+${mk} 2> ${log}
+if [ -e ninja.sh ]; then
+  if grep regenerating ${log} >/dev/null; then
+    echo 'Should not regenerate (unused env changed)'
   fi
   ./ninja.sh
 fi

--- a/var.cc
+++ b/var.cc
@@ -136,6 +136,13 @@ Var* Vars::Lookup(Symbol name) const {
   return v;
 }
 
+Var* Vars::Peek(Symbol name) const {
+  auto found = find(name);
+  if (found == end())
+    return kUndefined;
+  return found->second;
+}
+
 void Vars::Assign(Symbol name, Var* v, bool* readonly) {
   *readonly = false;
   auto p = emplace(name, v);

--- a/var.h
+++ b/var.h
@@ -190,6 +190,7 @@ class Vars : public unordered_map<Symbol, Var*> {
   ~Vars();
 
   Var* Lookup(Symbol name) const;
+  Var* Peek(Symbol name) const;
 
   void Assign(Symbol name, Var* v, bool* readonly);
 


### PR DESCRIPTION
With the introduction of deprecated / obsolete variable support, we started calling LookupVarInLocalScope on the variable we were setting with = or :=. This was fine, except it also marked those variables as used environment variables (whether they were set in the environment or not). So changing one of these environment variables would cause kati to regenerate the ninja file even though nothing would change.

To fix this, add new Peek* functions that don't record the variables as used, but can still be used to check to see if the variable has been deprecated or is obsolete.