### PR TITLE
Expand PeekVar to KATI_(deprecated|obsolete)_var

### DIFF
--- a/eval.cc
+++ b/eval.cc
@@ -391,6 +391,15 @@ Var* Evaluator::LookupVar(Symbol name) {
   return LookupVarGlobal(name);
 }
 
+Var* Evaluator::PeekVar(Symbol name) {
+  if (current_scope_) {
+    Var* v = current_scope_->Peek(name);
+    if (v->IsDefined())
+      return v;
+  }
+  return name.PeekGlobalVar();
+}
+
 Var* Evaluator::LookupVarInCurrentScope(Symbol name) {
   if (current_scope_) {
     return current_scope_->Lookup(name);

--- a/eval.h
+++ b/eval.h
@@ -47,6 +47,9 @@ class Evaluator {
   // For target specific variables.
   Var* LookupVarInCurrentScope(Symbol name);
 
+  // Equivalent to LookupVar, but doesn't mark as used.
+  Var* PeekVar(Symbol name);
+
   string EvalVar(Symbol name);
 
   const Loc& loc() const { return loc_; }

--- a/func.cc
+++ b/func.cc
@@ -835,7 +835,7 @@ void DeprecatedVarFunc(const vector<Value*>& args, Evaluator* ev, string*) {
 
   for (StringPiece var : WordScanner(vars_str)) {
     Symbol sym = Intern(var);
-    Var* v = ev->LookupVar(sym);
+    Var* v = ev->PeekVar(sym);
     if (!v->IsDefined()) {
       v = new SimpleVar(VarOrigin::FILE);
       sym.SetGlobalVar(v, false, nullptr);
@@ -871,7 +871,7 @@ void ObsoleteVarFunc(const vector<Value*>& args, Evaluator* ev, string*) {
 
   for (StringPiece var : WordScanner(vars_str)) {
     Symbol sym = Intern(var);
-    Var* v = ev->LookupVar(sym);
+    Var* v = ev->PeekVar(sym);
     if (!v->IsDefined()) {
       v = new SimpleVar(VarOrigin::FILE);
       sym.SetGlobalVar(v, false, nullptr);

--- a/testcase/ninja_regen.sh
+++ b/testcase/ninja_regen.sh
@@ -39,6 +39,8 @@ fi
 
 sleep_if_necessary 1
 cat <<EOF > Makefile
+\$(KATI_deprecated_var VAR4)
+\$(KATI_obsolete_var VAR5)
 VAR3 := unused
 all:
 	echo bar
@@ -90,6 +92,24 @@ ${mk} 2> ${log}
 if [ -e ninja.sh ]; then
   if grep regenerating ${log} >/dev/null; then
     echo 'Should not regenerate (unused env changed)'
+  fi
+  ./ninja.sh
+fi
+
+export VAR4=foo
+${mk} 2> ${log}
+if [ -e ninja.sh ]; then
+  if grep regenerating ${log} >/dev/null; then
+    echo 'Should not regenerate (deprecated env added)'
+  fi
+  ./ninja.sh
+fi
+
+export VAR5=foo
+${mk} 2> ${log}
+if [ -e ninja.sh ]; then
+  if grep regenerating ${log} >/dev/null; then
+    echo 'Should not regenerate (obsolete env added)'
   fi
   ./ninja.sh
 fi


### PR DESCRIPTION
So that marking a variable as deprecated or obsolete does not cause the variable to be inserted into the used environment table.