### PR TITLE
Find emulator performance fixes / debugging

### DIFF
--- a/find.cc
+++ b/find.cc
@@ -733,7 +733,8 @@ class FindCommandParser {
         if (!GetNextToken(&tok) || !tok.empty())
           return false;
         return true;
-      } else if (tok == "build/tools/findleaves.py") {
+      } else if (tok == "build/tools/findleaves.py" ||
+                 tok == "build/make/tools/findleaves.py") {
         if (!ParseFindLeaves())
           return false;
         return true;
@@ -1033,7 +1034,8 @@ FindCommand::~FindCommand() {}
 
 bool FindCommand::Parse(const string& cmd) {
   FindCommandParser fcp(cmd, this);
-  if (!HasWord(cmd, "find") && !HasWord(cmd, "build/tools/findleaves.py"))
+  if (!HasWord(cmd, "find") && !HasWord(cmd, "build/tools/findleaves.py") &&
+      !HasWord(cmd, "build/make/tools/findleaves.py"))
     return false;
 
   if (!fcp.Parse())

--- a/stats.h
+++ b/stats.h
@@ -17,6 +17,7 @@
 
 #include <mutex>
 #include <string>
+#include <unordered_map>
 
 using namespace std;
 
@@ -24,11 +25,12 @@ class Stats {
  public:
   explicit Stats(const char* name);
 
+  void DumpTop() const;
   string String() const;
 
  private:
   void Start();
-  double End();
+  double End(const char* msg);
 
   friend class ScopedStatsRecorder;
 
@@ -36,6 +38,7 @@ class Stats {
   double elapsed_;
   int cnt_;
   mutable mutex mu_;
+  unordered_map<string, double> detailed_;
 };
 
 class ScopedStatsRecorder {


### PR DESCRIPTION
Add some debugging to dump the longest 10 $(shell) commands when we're dumping statistics. This uncovered a performance issue where Kati didn't understand the new path to findleaves.py, so we weren't using the find emulator as much as we should have.