### PR TITLE
Support the implicit "-a" in find

### DIFF
--- a/find.cc
+++ b/find.cc
@@ -526,12 +526,16 @@ class FindCommandParser {
     while (true) {
       if (!GetNextToken(&tok))
         return NULL;
-      if (tok != "-and" && tok != "-a") {
-        UngetToken(tok);
-        return c.release();
+      if (tok == "-and" || tok == "-a") {
+        if (!GetNextToken(&tok) || tok.empty())
+          return NULL;
+      } else {
+        if (tok != "-not" && tok != "\\!" && tok != "\\(" && tok != "-name" &&
+            tok != "-type") {
+          UngetToken(tok);
+          return c.release();
+        }
       }
-      if (!GetNextToken(&tok) || tok.empty())
-        return NULL;
       unique_ptr<FindCond> r(ParseFact(tok));
       if (!r.get()) {
         return NULL;
@@ -562,7 +566,7 @@ class FindCommandParser {
   }
 
   // <expr> ::= <term> {<or> <term>}
-  // <term> ::= <fact> {<and> <fact>}
+  // <term> ::= <fact> {[<and>] <fact>}
   // <fact> ::= <not> <fact> | '\(' <expr> '\)' | <pred>
   // <not> ::= '-not' | '\!'
   // <and> ::= '-and' | '-a'

--- a/testcase/find_command.mk
+++ b/testcase/find_command.mk
@@ -67,6 +67,7 @@ endif
 	$(call run_find, find testdir -name "file1")
 	$(call run_find, find testdir -name "file1")
 	$(call run_find, find testdir -name "*1")
+	$(call run_find, find testdir -name "*1" -name "file*")
 	$(call run_find, find testdir -name "*1" -and -name "file*")
 	$(call run_find, find testdir -name "*1" -or -name "file*")
 	$(call run_find, find testdir -name "*1" -or -type f)


### PR DESCRIPTION
The find man page says that "expression expression" is equivalent to "expression -a expression".

This reduces the number of shell commands we need to run during regen check of one of the internal android trees by ~10%, which reduced the time spent in regen checking by ~60%.

```
before: *kati*: shell time (regen): 5.842119 / 516
after:  *kati*: shell time (regen): 2.377083 / 462
```