### PR TITLE
Add KATI_(deprecate|obsolete)_export

### DIFF
--- a/eval.h
+++ b/eval.h
@@ -15,6 +15,7 @@
 #ifndef EVAL_H_
 #define EVAL_H_
 
+#include <memory>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -98,6 +99,16 @@ class Evaluator {
   }
   void DumpStackStats() const;
 
+  bool ExportDeprecated() const { return export_message_ && !export_error_; };
+  bool ExportObsolete() const { return export_error_; };
+  void SetExportDeprecated(StringPiece msg) {
+    export_message_.reset(new string(msg.as_string()));
+  }
+  void SetExportObsolete(StringPiece msg) {
+    export_message_.reset(new string(msg.as_string()));
+    export_error_ = true;
+  }
+
  private:
   Var* EvalRHS(Symbol lhs,
                Value* rhs,
@@ -138,6 +149,9 @@ class Evaluator {
   size_t stack_size_;
   void* lowest_stack_;
   Loc lowest_loc_;
+
+  unique_ptr<string> export_message_;
+  bool export_error_;
 
   static unordered_set<Symbol> used_undefined_vars_;
 

--- a/func.cc
+++ b/func.cc
@@ -892,6 +892,36 @@ void ObsoleteVarFunc(const vector<Value*>& args, Evaluator* ev, string*) {
   }
 }
 
+void DeprecateExportFunc(const vector<Value*>& args, Evaluator* ev, string*) {
+  string msg = ". " + args[0]->Eval(ev);
+
+  if (ev->avoid_io()) {
+    ev->Error("*** $(KATI_deprecate_export) is not supported in rules.");
+  }
+
+  if (ev->ExportObsolete()) {
+    ev->Error("*** Export is already obsolete.");
+  } else if (ev->ExportDeprecated()) {
+    ev->Error("*** Export is already deprecated.");
+  }
+
+  ev->SetExportDeprecated(msg);
+}
+
+void ObsoleteExportFunc(const vector<Value*>& args, Evaluator* ev, string*) {
+  string msg = ". " + args[0]->Eval(ev);
+
+  if (ev->avoid_io()) {
+    ev->Error("*** $(KATI_obsolete_export) is not supported in rules.");
+  }
+
+  if (ev->ExportObsolete()) {
+    ev->Error("*** Export is already obsolete.");
+  }
+
+  ev->SetExportObsolete(msg);
+}
+
 FuncInfo g_func_infos[] = {
     {"patsubst", &PatsubstFunc, 3, 3, false, false},
     {"strip", &StripFunc, 1, 1, false, false},
@@ -939,6 +969,8 @@ FuncInfo g_func_infos[] = {
     /* Kati custom extension functions */
     {"KATI_deprecated_var", &DeprecatedVarFunc, 2, 1, false, false},
     {"KATI_obsolete_var", &ObsoleteVarFunc, 2, 1, false, false},
+    {"KATI_deprecate_export", &DeprecateExportFunc, 1, 1, false, false},
+    {"KATI_obsolete_export", &ObsoleteExportFunc, 1, 1, false, false},
 };
 
 unordered_map<StringPiece, FuncInfo*>* g_func_info_map;

--- a/testcase/deprecated_export.mk
+++ b/testcase/deprecated_export.mk
@@ -1,0 +1,21 @@
+# TODO(go): not implemented
+
+A := 1
+B := 2
+export A B
+
+$(KATI_deprecate_export Message)
+
+export C := ok
+unexport B
+
+ifndef KATI
+$(info Makefile:9: C: export has been deprecated. Message.)
+$(info Makefile:10: B: unexport has been deprecated. Message.)
+endif
+
+test:
+	echo $$(A)
+	echo $$(B)
+	echo $$(C)
+	echo Done

--- a/testcase/err_obsolete_export.mk
+++ b/testcase/err_obsolete_export.mk
@@ -1,0 +1,7 @@
+# TODO(go): not implemented
+
+export A := ok
+
+$(KATI_obsolete_export Message)
+
+export B := fail $(or $(KATI),$(error B: export is obsolete. Message))


### PR DESCRIPTION
Allow makefiles to mark the `export` and `unexport` keywords as deprecated or obsolete. In large builds like Android, we've got our own ways to set global environment variables, it's very unlikely that individual makefiles need to set an environment variable for every single rule.

We expect to eventually add environment variables to the list of inputs that ninja checks to see if a command needs to run again (currently it just checks the timestamps and commandline). Reducing the ability for makefiles to export global variables per-configuration means that we're more likely to share compile steps between configurations.