### PR TITLE
Add some warnings around common makefile issues

### DIFF
--- a/dep.cc
+++ b/dep.cc
@@ -349,6 +349,8 @@ class DepBuilder {
     if (g_flags.gen_all_targets) {
       unordered_set<Symbol> non_root_targets;
       for (const auto& p : rules_) {
+        if (p.first.get(0) == '.')
+          continue;
         for (const Rule* r : p.second.rules) {
           for (Symbol t : r->inputs)
             non_root_targets.insert(t);
@@ -359,7 +361,7 @@ class DepBuilder {
 
       for (const auto& p : rules_) {
         Symbol t = p.first;
-        if (!non_root_targets.count(t)) {
+        if (!non_root_targets.count(t) && t.get(0) != '.') {
           targets.push_back(p.first);
         }
       }

--- a/dep.cc
+++ b/dep.cc
@@ -716,6 +716,25 @@ class DepBuilder {
       }
     }
 
+    if (!g_flags.writable.empty() && !n->is_phony) {
+      bool found = false;
+      for (const auto& w : g_flags.writable) {
+        if (StringPiece(output.str()).starts_with(w)) {
+          found = true;
+          break;
+        }
+      }
+      if (!found) {
+        if (g_flags.werror_writable) {
+          ERROR_LOC(n->loc, "*** writing to readonly directory: \"%s\"",
+                    output.c_str());
+        } else {
+          WARN_LOC(n->loc, "warning: writing to readonly directory: \"%s\"",
+                   output.c_str());
+        }
+      }
+    }
+
     for (Symbol output : n->implicit_outputs) {
       done_[output] = n;
 
@@ -731,6 +750,25 @@ class DepBuilder {
                    "warning: PHONY target \"%s\" looks like a real file "
                    "(contains a \"/\")",
                    output.c_str());
+        }
+      }
+
+      if (!g_flags.writable.empty() && !n->is_phony) {
+        bool found = false;
+        for (const auto& w : g_flags.writable) {
+          if (StringPiece(output.str()).starts_with(w)) {
+            found = true;
+            break;
+          }
+        }
+        if (!found) {
+          if (g_flags.werror_writable) {
+            ERROR_LOC(n->loc, "*** writing to readonly directory: \"%s\"",
+                      output.c_str());
+          } else {
+            WARN_LOC(n->loc, "warning: writing to readonly directory: \"%s\"",
+                     output.c_str());
+          }
         }
       }
     }

--- a/dep.cc
+++ b/dep.cc
@@ -440,6 +440,13 @@ class DepBuilder {
     if (!IsSuffixRule(output))
       return false;
 
+    if (g_flags.werror_suffix_rules) {
+      ERROR_LOC(rule->loc, "*** suffix rules are obsolete: %s", output.c_str());
+    } else if (g_flags.warn_suffix_rules) {
+      WARN_LOC(rule->loc, "warning: suffix rules are deprecated: %s",
+               output.c_str());
+    }
+
     const StringPiece rest = StringPiece(output.str()).substr(1);
     size_t dot_index = rest.find('.');
 
@@ -479,8 +486,17 @@ class DepBuilder {
 
   void PopulateImplicitRule(const Rule* rule) {
     for (Symbol output_pattern : rule->output_patterns) {
-      if (output_pattern.str() != "%" || !IsIgnorableImplicitRule(rule))
+      if (output_pattern.str() != "%" || !IsIgnorableImplicitRule(rule)) {
+        if (g_flags.werror_implicit_rules) {
+          ERROR_LOC(rule->loc, "*** implicit rules are obsolete: %s",
+                    output_pattern.c_str());
+        } else if (g_flags.warn_implicit_rules) {
+          WARN_LOC(rule->loc, "warning: implicit rules are deprecated: %s",
+                   output_pattern.c_str());
+        }
+
         implicit_rules_->Add(output_pattern.str(), rule);
+      }
     }
   }
 

--- a/flags.cc
+++ b/flags.cc
@@ -113,6 +113,16 @@ void Flags::Parse(int argc, char** argv) {
       warn_suffix_rules = true;
     } else if (!strcmp(arg, "--werror_suffix_rules")) {
       werror_suffix_rules = true;
+    } else if (!strcmp(arg, "--warn_real_to_phony")) {
+      warn_real_to_phony = true;
+    } else if (!strcmp(arg, "--werror_real_to_phony")) {
+      warn_real_to_phony = true;
+      werror_real_to_phony = true;
+    } else if (!strcmp(arg, "--warn_phony_looks_real")) {
+      warn_phony_looks_real = true;
+    } else if (!strcmp(arg, "--werror_phony_looks_real")) {
+      warn_phony_looks_real = true;
+      werror_phony_looks_real = true;
     } else if (ParseCommandLineOptionWithArg("-j", argv, &i, &num_jobs_str)) {
       num_jobs = strtol(num_jobs_str, NULL, 10);
       if (num_jobs <= 0) {

--- a/flags.cc
+++ b/flags.cc
@@ -52,6 +52,7 @@ void Flags::Parse(int argc, char** argv) {
   subkati_args.push_back(argv[0]);
   num_jobs = num_cpus = sysconf(_SC_NPROCESSORS_ONLN);
   const char* num_jobs_str;
+  const char* writable_str;
 
   if (const char* makeflags = getenv("MAKEFLAGS")) {
     for (StringPiece tok : WordScanner(makeflags)) {
@@ -123,6 +124,8 @@ void Flags::Parse(int argc, char** argv) {
     } else if (!strcmp(arg, "--werror_phony_looks_real")) {
       warn_phony_looks_real = true;
       werror_phony_looks_real = true;
+    } else if (!strcmp(arg, "--werror_writable")) {
+      werror_writable = true;
     } else if (ParseCommandLineOptionWithArg("-j", argv, &i, &num_jobs_str)) {
       num_jobs = strtol(num_jobs_str, NULL, 10);
       if (num_jobs <= 0) {
@@ -149,6 +152,9 @@ void Flags::Parse(int argc, char** argv) {
                                              &ignore_dirty_pattern)) {
     } else if (ParseCommandLineOptionWithArg("--no_ignore_dirty", argv, &i,
                                              &no_ignore_dirty_pattern)) {
+    } else if (ParseCommandLineOptionWithArg("--writable", argv, &i,
+                                             &writable_str)) {
+      writable.push_back(writable_str);
     } else if (arg[0] == '-') {
       ERROR("Unknown flag: %s", arg);
     } else {

--- a/flags.cc
+++ b/flags.cc
@@ -99,6 +99,8 @@ void Flags::Parse(int argc, char** argv) {
       detect_depfiles = true;
     } else if (!strcmp(arg, "--color_warnings")) {
       color_warnings = true;
+    } else if (!strcmp(arg, "--no_builtin_rules")) {
+      no_builtin_rules = true;
     } else if (!strcmp(arg, "--werror_find_emulator")) {
       werror_find_emulator = true;
     } else if (!strcmp(arg, "--werror_overriding_commands")) {

--- a/flags.cc
+++ b/flags.cc
@@ -105,6 +105,14 @@ void Flags::Parse(int argc, char** argv) {
       werror_find_emulator = true;
     } else if (!strcmp(arg, "--werror_overriding_commands")) {
       werror_overriding_commands = true;
+    } else if (!strcmp(arg, "--warn_implicit_rules")) {
+      warn_implicit_rules = true;
+    } else if (!strcmp(arg, "--werror_implicit_rules")) {
+      werror_implicit_rules = true;
+    } else if (!strcmp(arg, "--warn_suffix_rules")) {
+      warn_suffix_rules = true;
+    } else if (!strcmp(arg, "--werror_suffix_rules")) {
+      werror_suffix_rules = true;
     } else if (ParseCommandLineOptionWithArg("-j", argv, &i, &num_jobs_str)) {
       num_jobs = strtol(num_jobs_str, NULL, 10);
       if (num_jobs <= 0) {

--- a/flags.h
+++ b/flags.h
@@ -40,6 +40,7 @@ struct Flags {
   bool regen_ignoring_kati_binary;
   bool use_find_emulator;
   bool color_warnings;
+  bool no_builtin_rules;
   bool werror_find_emulator;
   bool werror_overriding_commands;
   const char* goma_dir;

--- a/flags.h
+++ b/flags.h
@@ -43,6 +43,10 @@ struct Flags {
   bool no_builtin_rules;
   bool werror_find_emulator;
   bool werror_overriding_commands;
+  bool warn_implicit_rules;
+  bool werror_implicit_rules;
+  bool warn_suffix_rules;
+  bool werror_suffix_rules;
   const char* goma_dir;
   const char* ignore_dirty_pattern;
   const char* no_ignore_dirty_pattern;

--- a/flags.h
+++ b/flags.h
@@ -51,6 +51,7 @@ struct Flags {
   bool werror_real_to_phony;
   bool warn_phony_looks_real;
   bool werror_phony_looks_real;
+  bool werror_writable;
   const char* goma_dir;
   const char* ignore_dirty_pattern;
   const char* no_ignore_dirty_pattern;
@@ -64,6 +65,7 @@ struct Flags {
   vector<const char*> subkati_args;
   vector<Symbol> targets;
   vector<StringPiece> cl_vars;
+  vector<string> writable;
 
   void Parse(int argc, char** argv);
 };

--- a/flags.h
+++ b/flags.h
@@ -47,6 +47,10 @@ struct Flags {
   bool werror_implicit_rules;
   bool warn_suffix_rules;
   bool werror_suffix_rules;
+  bool warn_real_to_phony;
+  bool werror_real_to_phony;
+  bool warn_phony_looks_real;
+  bool werror_phony_looks_real;
   const char* goma_dir;
   const char* ignore_dirty_pattern;
   const char* no_ignore_dirty_pattern;

--- a/main.cc
+++ b/main.cc
@@ -82,16 +82,20 @@ static void ReadBootstrapMakefile(const vector<Symbol>& targets,
        // Overwrite $SHELL environment variable.
        "SHELL=/bin/sh\n"
        // TODO: Add more builtin vars.
-
-       // http://www.gnu.org/software/make/manual/make.html#Catalogue-of-Rules
-       // The document above is actually not correct. See default.c:
-       // http://git.savannah.gnu.org/cgit/make.git/tree/default.c?id=4.1
-       ".c.o:\n"
-       "\t$(CC) $(CFLAGS) $(CPPFLAGS) $(TARGET_ARCH) -c -o $@ $<\n"
-       ".cc.o:\n"
-       "\t$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(TARGET_ARCH) -c -o $@ $<\n"
-       // TODO: Add more builtin rules.
       );
+
+  if (!g_flags.no_builtin_rules) {
+    bootstrap += (
+        // http://www.gnu.org/software/make/manual/make.html#Catalogue-of-Rules
+        // The document above is actually not correct. See default.c:
+        // http://git.savannah.gnu.org/cgit/make.git/tree/default.c?id=4.1
+        ".c.o:\n"
+        "\t$(CC) $(CFLAGS) $(CPPFLAGS) $(TARGET_ARCH) -c -o $@ $<\n"
+        ".cc.o:\n"
+        "\t$(CXX) $(CXXFLAGS) $(CPPFLAGS) $(TARGET_ARCH) -c -o $@ $<\n"
+        // TODO: Add more builtin rules.
+    );
+  }
   if (g_flags.generate_ninja) {
     bootstrap += StringPrintf("MAKE?=make -j%d\n",
                               g_flags.num_jobs <= 1 ? 1 : g_flags.num_jobs / 2);

--- a/testcase/implicit_pattern_rule_warn.sh
+++ b/testcase/implicit_pattern_rule_warn.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+#
+# Copyright 2018 Google Inc. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -u
+
+mk="$@"
+
+cat <<EOF > Makefile
+test:
+	@echo "PASS"
+# Static pattern rules are still supported
+a.foo b.foo: %.foo: %.bar
+	cp $< $@
+%.foo: %.bar
+	cp $< $@
+EOF
+
+if echo "${mk}" | grep -qv "kati"; then
+  # Make doesn't support these warnings, so write the expected output.
+  echo 'Makefile:6: warning: implicit rules are deprecated: %.foo'
+  echo 'PASS'
+else
+  ${mk} --no_builtin_rules --warn_implicit_rules 2>&1
+fi
+
+if echo "${mk}" | grep -qv "kati"; then
+  # Make doesn't support these warnings, so write the expected output.
+  echo 'Makefile:6: *** implicit rules are obsolete: %.foo'
+else
+  ${mk} --no_builtin_rules --werror_implicit_rules 2>&1
+fi

--- a/testcase/phony_looks_real.sh
+++ b/testcase/phony_looks_real.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+#
+# Copyright 2018 Google Inc. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -u
+
+mk="$@"
+
+cat <<EOF > Makefile
+test: foo/bar foo/baz
+foo/bar: .KATI_IMPLICIT_OUTPUTS := foo/baz
+foo/bar:
+	@echo "END"
+.PHONY: test foo/bar
+EOF
+
+if echo "${mk}" | grep -qv "kati"; then
+  # Make doesn't support these warnings, so write the expected output.
+  echo 'Makefile:4: warning: PHONY target "foo/bar" looks like a real file (contains a "/")'
+  echo 'Makefile:4: warning: PHONY target "foo/baz" looks like a real file (contains a "/")'
+  echo 'END'
+else
+  ${mk} --warn_phony_looks_real 2>&1
+fi
+
+if echo "${mk}" | grep -qv "kati"; then
+  # Make doesn't support these warnings, so write the expected output.
+  echo 'Makefile:4: *** PHONY target "foo/bar" looks like a real file (contains a "/")'
+else
+  ${mk} --werror_phony_looks_real 2>&1
+fi

--- a/testcase/real_to_phony.sh
+++ b/testcase/real_to_phony.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+#
+# Copyright 2018 Google Inc. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -u
+
+mk="$@"
+
+cat <<EOF > Makefile
+test: foo
+foo: bar
+	@echo "END"
+bar:
+	@exit 0
+.PHONY: bar
+EOF
+
+if echo "${mk}" | grep -qv "kati"; then
+  # Make doesn't support these warnings, so write the expected output.
+  echo 'Makefile:3: warning: real file "foo" depends on PHONY target "bar"'
+  echo 'END'
+else
+  ${mk} --warn_real_to_phony 2>&1
+fi
+
+if echo "${mk}" | grep -qv "kati"; then
+  # Make doesn't support these warnings, so write the expected output.
+  echo 'Makefile:3: *** real file "foo" depends on PHONY target "bar"'
+else
+  ${mk} --werror_real_to_phony 2>&1
+fi

--- a/testcase/suffix_rule_warn.sh
+++ b/testcase/suffix_rule_warn.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# Copyright 2018 Google Inc. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -u
+
+mk="$@"
+
+cat <<EOF > Makefile
+test:
+	@echo "PASS"
+.c.o:
+	cp $< $@
+EOF
+
+if echo "${mk}" | grep -qv "kati"; then
+  # Make doesn't support these warnings, so write the expected output.
+  echo 'Makefile:3: warning: suffix rules are deprecated: .c.o'
+  echo 'PASS'
+else
+  ${mk} --no_builtin_rules --warn_suffix_rules 2>&1
+fi
+
+if echo "${mk}" | grep -qv "kati"; then
+  # Make doesn't support these warnings, so write the expected output.
+  echo 'Makefile:3: *** suffix rules are obsolete: .c.o'
+else
+  ${mk} --no_builtin_rules --werror_suffix_rules 2>&1
+fi

--- a/testcase/writable.sh
+++ b/testcase/writable.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+#
+# Copyright 2018 Google Inc. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -u
+
+mk="$@"
+
+cat <<EOF > Makefile
+test: out/foo.o
+test2:
+out/foo.o: foo.c foo.h test2
+	@echo "END"
+foo.c:
+	@exit 0
+foo.h: foo.c
+
+.PHONY: test test2
+EOF
+
+# TODO: test implicit outputs
+
+if echo "${mk}" | grep -qv "kati"; then
+  # Make doesn't support these warnings, so write the expected output.
+  echo 'Makefile:6: warning: writing to readonly directory: "foo.c"'
+  echo 'Makefile:7: warning: writing to readonly directory: "foo.h"'
+  echo 'END'
+else
+  ${mk} --writable=out/ 2>&1
+fi
+
+if echo "${mk}" | grep -qv "kati"; then
+  # Make doesn't support these warnings, so write the expected output.
+  echo 'Makefile:6: *** writing to readonly directory: "foo.c"'
+else
+  ${mk} --writable=out/ --werror_writable 2>&1
+fi


### PR DESCRIPTION
For large build systems using a single make context, we see a number of (semi-)common issues that come up when people write Makefiles:

1. They attempt to add phony targets in the dependency chain for build targets instead of using/producing real timestamp or output files. This appears to work, but can cause some significant performance issues, since anything that depends on these targets will be rebuilt on every incremental build. So add some warnings(/errors) around .PHONY targets that look like real files, and warnings(/errors) when real files depend on phony targets.

2. Implicit rules can be used relatively well (and we do still use them in a few situations), but they can also be abused fairly easily when the pattern is very open. The worst case we've seen has been something similar to the old suffix rules (which we already attempt to turn off):

```makefile
%_suffix.so : %.so
    cp $< $@
```

Which with a sufficiently common suffix, could be implicitly adding copy rules all over the output and source trees. So give an option to turn suffix/implicit rules into warnings/errors.

3. Adding rules to generate files into the source directory. This change won't catch every case of the build writing in the source directory (we'll eventually be turning the source directory readonly in most cases), but it can catch a subset of these problems earlier, with better error messages.