### PR TITLE
Fix bug around empty targets in static pattern rules

### DIFF
--- a/rule.cc
+++ b/rule.cc
@@ -138,6 +138,12 @@ void ParseRule(Loc& loc,
     ERROR_LOC(loc, "*** mixed implicit and normal rules: deprecated syntax");
   }
 
+  // Empty static patterns should not produce rules, but need to eat the commands
+  // So return a rule with no outputs nor output_patterns
+  if (rule->outputs.empty()) {
+    return;
+  }
+
   StringPiece second = rest.substr(0, index);
   StringPiece third = rest.substr(index + 1);
 

--- a/testcase/empty_static_pattern.sh
+++ b/testcase/empty_static_pattern.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+#
+# Copyright 2018 Google Inc. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -u
+
+mk="$@"
+
+cat <<EOF > Makefile
+test:
+	@echo "PASS"
+list :=
+\$(list): %.foo: %.bar
+	cp \$< \$@
+EOF
+
+if echo "${mk}" | grep -qv "kati"; then
+  # Make doesn't support these warnings, so write the expected output.
+  echo 'PASS'
+else
+  ${mk} --no_builtin_rules --werror_implicit_rules 2>&1
+fi


### PR DESCRIPTION
Static pattern rules were being converted to implicit rules when the
target list was empty, since Kati was just looking at which lists were
empty to decide which type of rule it was.

Instead, empty the output patterns list if we've parsed a static pattern
rule without any outputs.