### PR TITLE
Clean up Symbol handling.

### DIFF
--- a/eval.cc
+++ b/eval.cc
@@ -38,8 +38,7 @@ Evaluator::Evaluator()
       eval_depth_(0),
       posix_sym_(Intern(".POSIX")),
       is_posix_(false),
-      export_error_(false),
-      kati_readonly_(Intern(".KATI_READONLY")) {
+      export_error_(false) {
 #if defined(__APPLE__)
   stack_size_ = pthread_get_stacksize_np(pthread_self());
   stack_addr_ = (char*)pthread_get_stackaddr_np(pthread_self()) - stack_size_;
@@ -137,7 +136,7 @@ void Evaluator::EvalAssign(const AssignStmt* stmt) {
   if (lhs.empty())
     Error("*** empty variable name.");
 
-  if (lhs == kati_readonly_) {
+  if (lhs == kKatiReadonlySym) {
     string rhs;
     stmt->rhs->Eval(this, &rhs);
     for (auto const& name : WordScanner(rhs)) {
@@ -224,7 +223,7 @@ void Evaluator::EvalRule(const RuleStmt* stmt) {
 
     current_scope_ = p.first->second;
 
-    if (lhs == kati_readonly_) {
+    if (lhs == kKatiReadonlySym) {
       string rhs_value;
       rhs->Eval(this, &rhs_value);
       for (auto const& name : WordScanner(rhs_value)) {
@@ -266,7 +265,7 @@ void Evaluator::EvalCommand(const CommandStmt* stmt) {
   last_rule_->cmds.push_back(stmt->expr);
   if (last_rule_->cmd_lineno == 0)
     last_rule_->cmd_lineno = stmt->loc().lineno;
-  LOG("Command: %s", stmt->expr->DebugString().c_str());
+  LOG("Command: %s", Value::DebugString(stmt->expr).c_str());
 }
 
 void Evaluator::EvalIf(const IfStmt* stmt) {
@@ -462,4 +461,4 @@ void Evaluator::DumpStackStats() const {
            LOCF(lowest_loc_));
 }
 
-unordered_set<Symbol> Evaluator::used_undefined_vars_;
+SymbolSet Evaluator::used_undefined_vars_;

--- a/eval.h
+++ b/eval.h
@@ -78,7 +78,7 @@ class Evaluator {
   }
   void clear_delayed_output_commands() { delayed_output_commands_.clear(); }
 
-  static const unordered_set<Symbol>& used_undefined_vars() {
+  static const SymbolSet& used_undefined_vars() {
     return used_undefined_vars_;
   }
 
@@ -153,9 +153,7 @@ class Evaluator {
   unique_ptr<string> export_message_;
   bool export_error_;
 
-  static unordered_set<Symbol> used_undefined_vars_;
-
-  Symbol kati_readonly_;
+  static SymbolSet used_undefined_vars_;
 };
 
 #endif  // EVAL_H_

--- a/expr.cc
+++ b/expr.cc
@@ -39,11 +39,8 @@ Value::Value() {}
 
 Value::~Value() {}
 
-string Value::DebugString() const {
-  if (static_cast<const Value*>(this)) {
-    return NoLineBreak(DebugString_());
-  }
-  return "(null)";
+string Value::DebugString(const Value *v) {
+  return v ? NoLineBreak(v->DebugString_()) : "(null)";
 }
 
 class Literal : public Value {
@@ -94,7 +91,7 @@ class Expr : public Value {
       } else {
         r += ", ";
       }
-      r += v->DebugString();
+      r += DebugString(v);
     }
     if (!r.empty())
       r += ")";
@@ -152,7 +149,7 @@ class VarRef : public Value {
   }
 
   virtual string DebugString_() const override {
-    return StringPrintf("VarRef(%s)", name_->DebugString().c_str());
+    return StringPrintf("VarRef(%s)", Value::DebugString(name_).c_str());
   }
 
  private:
@@ -189,9 +186,9 @@ class VarSubst : public Value {
   }
 
   virtual string DebugString_() const override {
-    return StringPrintf("VarSubst(%s:%s=%s)", name_->DebugString().c_str(),
-                        pat_->DebugString().c_str(),
-                        subst_->DebugString().c_str());
+    return StringPrintf("VarSubst(%s:%s=%s)", Value::DebugString(name_).c_str(),
+                        Value::DebugString(pat_).c_str(),
+                        Value::DebugString(subst_).c_str());
   }
 
  private:
@@ -567,7 +564,7 @@ Value* ParseExpr(const Loc& loc, StringPiece s, ParseExprOpt opt) {
 string JoinValues(const vector<Value*>& vals, const char* sep) {
   vector<string> val_strs;
   for (Value* v : vals) {
-    val_strs.push_back(v->DebugString());
+    val_strs.push_back(Value::DebugString(v));
   }
   return JoinStrings(val_strs, sep);
 }

--- a/expr.h
+++ b/expr.h
@@ -45,7 +45,7 @@ class Value : public Evaluable {
   // Only safe after IsLiteral() returns true.
   virtual StringPiece GetLiteralValueUnsafe() const { return ""; }
 
-  string DebugString() const;
+  static string DebugString(const Value *);
 
  protected:
   Value();

--- a/func.cc
+++ b/func.cc
@@ -64,6 +64,7 @@ void StripShellComment(string* cmd) {
             in++;
           break;
         }
+        /* FALLTHRU */
 
       case '\'':
       case '"':
@@ -613,7 +614,7 @@ void CallFunc(const vector<Value*>& args, Evaluator* ev, string* s) {
   vector<unique_ptr<ScopedGlobalVar>> sv;
   for (size_t i = 1;; i++) {
     string s;
-    Symbol tmpvar_name_sym(Symbol::IsUninitialized{});
+    Symbol tmpvar_name_sym;
     if (i < sizeof(tmpvar_names) / sizeof(tmpvar_names[0])) {
       tmpvar_name_sym = tmpvar_names[i];
     } else {

--- a/ninja.cc
+++ b/ninja.cc
@@ -228,9 +228,10 @@ class NinjaGenerator {
   }
 
   void PopulateNinjaNode(DepNode* node) {
-    auto p = done_.insert(node->output);
-    if (!p.second)
+    if (done_.exists(node->output)) {
       return;
+    }
+    done_.insert(node->output);
 
     // A hack to exclude out phony target in Android. If this exists,
     // "ninja -t clean" tries to remove this directory and fails.
@@ -628,7 +629,7 @@ class NinjaGenerator {
       fprintf(fp_, "%s", buf.str().c_str());
     }
 
-    unordered_set<Symbol> used_env_vars(Vars::used_env_vars());
+    SymbolSet used_env_vars(Vars::used_env_vars());
     // PATH changes $(shell).
     used_env_vars.insert(Intern("PATH"));
     for (Symbol e : used_env_vars) {
@@ -716,7 +717,6 @@ class NinjaGenerator {
     for (Symbol v : Evaluator::used_undefined_vars()) {
       DumpString(fp, v.str());
     }
-
     DumpInt(fp, used_envs_.size());
     for (const auto& p : used_envs_) {
       DumpString(fp, p.first);
@@ -785,7 +785,7 @@ class NinjaGenerator {
   CommandEvaluator ce_;
   Evaluator* ev_;
   FILE* fp_;
-  unordered_set<Symbol> done_;
+  SymbolSet done_;
   int rule_id_;
   bool use_goma_;
   string gomacc_;

--- a/stmt.cc
+++ b/stmt.cc
@@ -27,8 +27,8 @@ Stmt::~Stmt() {}
 
 string RuleStmt::DebugString() const {
   return StringPrintf("RuleStmt(expr=%s term=%d after_term=%s loc=%s:%d)",
-                      expr->DebugString().c_str(), term,
-                      after_term->DebugString().c_str(), LOCF(loc()));
+                      Value::DebugString(expr).c_str(), term,
+                      Value::DebugString(after_term).c_str(), LOCF(loc()));
 }
 
 string AssignStmt::DebugString() const {
@@ -62,7 +62,7 @@ string AssignStmt::DebugString() const {
   return StringPrintf(
       "AssignStmt(lhs=%s rhs=%s (%s) "
       "opstr=%s dir=%s loc=%s:%d)",
-      lhs->DebugString().c_str(), rhs->DebugString().c_str(),
+      Value::DebugString(lhs).c_str(), Value::DebugString(rhs).c_str(),
       NoLineBreak(orig_rhs.as_string()).c_str(), opstr, dirstr, LOCF(loc()));
 }
 
@@ -80,7 +80,7 @@ Symbol AssignStmt::GetLhsSymbol(Evaluator* ev) const {
 }
 
 string CommandStmt::DebugString() const {
-  return StringPrintf("CommandStmt(%s, loc=%s:%d)", expr->DebugString().c_str(),
+  return StringPrintf("CommandStmt(%s, loc=%s:%d)", Value::DebugString(expr).c_str(),
                       LOCF(loc()));
 }
 
@@ -101,19 +101,19 @@ string IfStmt::DebugString() const {
       break;
   }
   return StringPrintf("IfStmt(op=%s, lhs=%s, rhs=%s t=%zu f=%zu loc=%s:%d)",
-                      opstr, lhs->DebugString().c_str(),
-                      rhs->DebugString().c_str(), true_stmts.size(),
+                      opstr, Value::DebugString(lhs).c_str(),
+                      Value::DebugString(rhs).c_str(), true_stmts.size(),
                       false_stmts.size(), LOCF(loc()));
 }
 
 string IncludeStmt::DebugString() const {
-  return StringPrintf("IncludeStmt(%s, loc=%s:%d)", expr->DebugString().c_str(),
+  return StringPrintf("IncludeStmt(%s, loc=%s:%d)", Value::DebugString(expr).c_str(),
                       LOCF(loc()));
 }
 
 string ExportStmt::DebugString() const {
   return StringPrintf("ExportStmt(%s, %d, loc=%s:%d)",
-                      expr->DebugString().c_str(), is_export, LOCF(loc()));
+                      Value::DebugString(expr).c_str(), is_export, LOCF(loc()));
 }
 
 string ParseErrorStmt::DebugString() const {

--- a/stmt.h
+++ b/stmt.h
@@ -86,7 +86,7 @@ struct AssignStmt : public Stmt {
   AssignOp op;
   AssignDirective directive;
 
-  AssignStmt() : lhs_sym_cache_(Symbol::IsUninitialized{}) {}
+  AssignStmt() {}
   virtual ~AssignStmt();
 
   virtual void Eval(Evaluator* ev) const;

--- a/symtab.cc
+++ b/symtab.cc
@@ -38,8 +38,9 @@ struct SymbolData {
 vector<string*>* g_symbols;
 static vector<SymbolData> g_symbol_data;
 
-Symbol kEmptySym = Symbol(Symbol::IsUninitialized());
-Symbol kShellSym = Symbol(Symbol::IsUninitialized());
+Symbol kEmptySym;
+Symbol kShellSym;
+Symbol kKatiReadonlySym;
 
 Symbol::Symbol(int v) : v_(v) {}
 
@@ -125,6 +126,7 @@ class Symtab {
 
     kEmptySym = Intern("");
     kShellSym = Intern("SHELL");
+    kKatiReadonlySym = Intern(".KATI_READONLY");
   }
 
   ~Symtab() {

--- a/symtab.h
+++ b/symtab.h
@@ -15,6 +15,7 @@
 #ifndef SYMTAB_H_
 #define SYMTAB_H_
 
+#include <bitset>
 #include <string>
 #include <vector>
 
@@ -29,8 +30,7 @@ class Var;
 
 class Symbol {
  public:
-  struct IsUninitialized {};
-  explicit Symbol(IsUninitialized) : v_(-1) {}
+  explicit Symbol() : v_(-1) {}
 
   const string& str() const { return *((*g_symbols)[v_]); }
 
@@ -61,6 +61,137 @@ class Symbol {
   int v_;
 
   friend class Symtab;
+  friend class SymbolSet;
+};
+
+/* A set of symbols represented as bitmap indexed by Symbol's ordinal value. */
+class SymbolSet {
+ public:
+  SymbolSet():low_(0), high_(0) {}
+
+  /* Returns true if Symbol belongs to this set. */
+  bool exists(Symbol sym) const {
+    size_t bit_nr = static_cast<size_t>(sym.val());
+    return sym.IsValid() && bit_nr >= low_ && bit_nr < high_ &&
+        bits_[(bit_nr - low_) / 64][(bit_nr - low_) % 64];
+  }
+
+  /* Adds Symbol to this set.  */
+  void insert(Symbol sym) {
+    if (!sym.IsValid()) {
+      return;
+    }
+    size_t bit_nr = static_cast<size_t>(sym.val());
+    if (bit_nr < low_ || bit_nr >= high_) {
+        resize(bit_nr);
+    }
+    bits_[(bit_nr - low_) / 64][(bit_nr - low_) % 64] = true;
+  }
+
+  /* Returns the number of Symbol's in this set.  */
+  size_t size() const {
+    size_t n = 0;
+    for (auto const& bitset : bits_) {
+      n += bitset.count();
+    }
+    return n;
+  }
+
+  /* Allow using foreach.
+   * E.g.,
+   *   SymbolSet symbol_set;
+   *   for (auto const& symbol: symbol_set) { ... }
+   */
+  class iterator {
+    const SymbolSet* bitset_;
+    size_t pos_;
+
+    iterator(const SymbolSet* bitset, size_t pos)
+        :bitset_(bitset), pos_(pos) {
+    }
+
+    /* Proceed to the next Symbol.  */
+    void next() {
+      size_t bit_nr = (pos_ > bitset_->low_) ? pos_ - bitset_->low_ : 0;
+      while (bit_nr < (bitset_->high_ - bitset_->low_)) {
+        if ((bit_nr % 64) == 0 && !bitset_->bits_[bit_nr / 64].any()) {
+          bit_nr += 64;
+          continue;
+        }
+        if (bitset_->bits_[bit_nr / 64][bit_nr % 64]) {
+          break;
+        }
+        ++bit_nr;
+      }
+      pos_ = bitset_->low_ + bit_nr;
+    }
+
+   public:
+    iterator& operator++() {
+      if (pos_ < bitset_->high_) {
+        ++pos_;
+        next();
+      }
+      return *this;
+    }
+
+    bool operator==(iterator other) const {
+      return bitset_ == other.bitset_ && pos_ == other.pos_;
+    }
+
+    bool operator!=(iterator other) const {
+      return !(*this == other);
+    }
+
+    Symbol operator*() {return Symbol(pos_); }
+
+    friend class SymbolSet;
+  };
+
+  iterator begin() const {
+    iterator it(this, low_);
+    it.next();
+    return it;
+  }
+
+  iterator end() const {
+    return iterator(this, high_);
+  }
+
+ private:
+  friend class iterator;
+
+  /* Ensure that given bit number is in [low_, high_)  */
+  void resize(size_t bit_nr) {
+    size_t new_low = bit_nr & ~63;
+    size_t new_high = (bit_nr + 64) & ~63;
+    if (bits_.empty()) {
+      high_ = low_ = new_low;
+    }
+    if (new_low > low_) {
+      new_low = low_;
+    }
+    if (new_high <= high_) {
+      new_high = high_;
+    }
+    if (new_low == low_) {
+      bits_.resize((new_high - new_low) / 64);
+    } else {
+      std::vector<std::bitset<64> > newbits((new_high - new_low)/64);
+      std::copy(bits_.begin(), bits_.end(), newbits.begin() + (low_ - new_low) / 64);
+      bits_.swap(newbits);
+    }
+    low_ = new_low;
+    high_ = new_high;
+  }
+
+  /* Keep only the (aligned) range where at least one bit has been set.
+   * E.g., if we only ever set bits 65 and 141, |low_| will be 64, |high_|
+   * will be 192, and |bits_| will have 2 elements.
+   */
+  size_t low_;
+  size_t high_;
+  std::vector<std::bitset<64> > bits_;
 };
 
 class ScopedGlobalVar {
@@ -90,6 +221,7 @@ struct hash<Symbol> {
 
 extern Symbol kEmptySym;
 extern Symbol kShellSym;
+extern Symbol kKatiReadonlySym;
 
 void InitSymtab();
 void QuitSymtab();

--- a/var.cc
+++ b/var.cc
@@ -97,7 +97,7 @@ StringPiece RecursiveVar::String() const {
 }
 
 string RecursiveVar::DebugString() const {
-  return v_->DebugString();
+  return Value::DebugString(v_);
 }
 
 UndefinedVar::UndefinedVar() {}
@@ -165,7 +165,7 @@ void Vars::Assign(Symbol name, Var* v, bool* readonly) {
   }
 }
 
-unordered_set<Symbol> Vars::used_env_vars_;
+SymbolSet Vars::used_env_vars_;
 
 ScopedVar::ScopedVar(Vars* vars, Symbol name, Var* var)
     : vars_(vars), orig_(NULL) {

--- a/var.h
+++ b/var.h
@@ -196,10 +196,10 @@ class Vars : public unordered_map<Symbol, Var*> {
 
   static void add_used_env_vars(Symbol v);
 
-  static const unordered_set<Symbol>& used_env_vars() { return used_env_vars_; }
+  static const SymbolSet used_env_vars() { return used_env_vars_; }
 
  private:
-  static unordered_set<Symbol> used_env_vars_;
+  static SymbolSet used_env_vars_;
 };
 
 class ScopedVar {


### PR DESCRIPTION
* Introduce SymbolSet class. As each Symbol contains sequentially
assigned ordinal value, representing a set of Symbols as a growable
bitset is faster and more space-efficient than generic unordered_bitmap
(for the full build, we save about 1500MB).
* Remove useless constructor argument.
* Make a Symbol for .KATI_READONLY constant instead of Evaluator member.
* Avoid testing 'this' for nullness in Value::DebugString, it's not
standard-compliant. Make Value::DebugString static instead.
* Avoid 'fallthrough' compiler warning.