### PR TITLE
Implement 'final' assignments.

### DIFF
--- a/eval.h
+++ b/eval.h
@@ -122,6 +122,12 @@ class Evaluator {
   // Equivalent to LookupVarInCurrentScope, but doesn't mark as used.
   Var* PeekVarInCurrentScope(Symbol name);
 
+  void MarkVarsReadonly(Value *var_list);
+
+  void EvalRuleSpecificAssign(const vector<Symbol>& targets,
+                              const RuleStmt *stmt,
+                              const StringPiece& lhs_string, size_t separator_pos);
+
   unordered_map<Symbol, Vars*> rule_vars_;
   vector<const Rule*> rules_;
   unordered_map<Symbol, bool> exports_;

--- a/rule.h
+++ b/rule.h
@@ -37,6 +37,16 @@ class Rule {
 
   string DebugString() const;
 
+  void ParseInputs(const StringPiece& inputs_string);
+
+  void ParsePrerequisites(const StringPiece& line,
+                          size_t pos,
+                          const RuleStmt* rule_stmt);
+
+  static bool IsPatternRule(const StringPiece& target_string) {
+    return target_string.find('%') != string::npos;
+  }
+
   vector<Symbol> outputs;
   vector<Symbol> inputs;
   vector<Symbol> order_only_inputs;
@@ -51,22 +61,5 @@ class Rule {
   void Error(const string& msg) { ERROR_LOC(loc, "%s", msg.c_str()); }
 };
 
-struct RuleVarAssignment {
-  vector<Symbol> outputs;
-  StringPiece lhs;
-  StringPiece rhs;
-  AssignOp op;
-};
-
-// If |rule| is not NULL, |rule_var| is filled. If the expression
-// after the terminator |term| is needed (this happens only when
-// |term| is '='), |after_term_fn| will be called to obtain the right
-// hand side.
-void ParseRule(Loc& loc,
-               StringPiece line,
-               char term,
-               const function<string()>& after_term_fn,
-               Rule** rule,
-               RuleVarAssignment* rule_var);
 
 #endif  // RULE_H_

--- a/stmt.cc
+++ b/stmt.cc
@@ -26,9 +26,9 @@ Stmt::Stmt() {}
 Stmt::~Stmt() {}
 
 string RuleStmt::DebugString() const {
-  return StringPrintf("RuleStmt(expr=%s term=%d after_term=%s loc=%s:%d)",
-                      Value::DebugString(expr).c_str(), term,
-                      Value::DebugString(after_term).c_str(), LOCF(loc()));
+  return StringPrintf("RuleStmt(lhs=%s sep=%d rhs=%s loc=%s:%d)",
+                      Value::DebugString(lhs).c_str(), sep,
+                      Value::DebugString(rhs).c_str(), LOCF(loc()));
 }
 
 string AssignStmt::DebugString() const {
@@ -122,8 +122,8 @@ string ParseErrorStmt::DebugString() const {
 }
 
 RuleStmt::~RuleStmt() {
-  delete expr;
-  delete after_term;
+  delete lhs;
+  delete rhs;
 }
 
 void RuleStmt::Eval(Evaluator* ev) const {

--- a/stmt.h
+++ b/stmt.h
@@ -67,10 +67,17 @@ struct Stmt {
   StringPiece orig_;
 };
 
+/* Parsed "rule statement" before evaluation is kept as
+ *    <lhs> <sep> <rhs>
+ * where <lhs> and <rhs> as Value instances. <sep> is either command
+ * separator (';') or an assignment ('=' or '=$=').
+ * Until we evaluate <lhs>, we don't know whether it is a rule or
+ * a rule-specific variable assignment.
+ */
 struct RuleStmt : public Stmt {
-  Value* expr;
-  char term;
-  Value* after_term;
+  Value* lhs;
+  enum { SEP_NULL, SEP_SEMICOLON, SEP_EQ, SEP_FINALEQ } sep;
+  Value* rhs;
 
   virtual ~RuleStmt();
 
@@ -85,8 +92,9 @@ struct AssignStmt : public Stmt {
   StringPiece orig_rhs;
   AssignOp op;
   AssignDirective directive;
+  bool is_final;
 
-  AssignStmt() {}
+  AssignStmt() : is_final(false) {}
   virtual ~AssignStmt();
 
   virtual void Eval(Evaluator* ev) const;

--- a/testcase/final_global.sh
+++ b/testcase/final_global.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+#
+# Copyright 2018 Google Inc. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -u
+
+mk="$@"
+
+function build() {
+  cat <<EOF > Makefile
+FOO $1$= bar
+FOO $2 baz
+all:
+EOF
+
+  echo "Testcase: $1 $2"
+  if echo "${mk}" | grep -q "^make"; then
+    # Make doesn't support final assignment
+    echo "Makefile:2: *** cannot assign to readonly variable: FOO"
+  else
+    ${mk} 2>&1 && echo "Clean exit"
+  fi
+}
+
+build "=" "="
+build "=" ":="
+build "=" "+="
+
+build ":=" ":="
+build ":=" "+="
+build ":=" "="

--- a/testcase/final_rule.sh
+++ b/testcase/final_rule.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+# Copyright 2018 Google Inc. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -u
+
+mk="$@"
+
+if echo "${mk}" | grep -q "^make"; then
+  # Make doesn't support final assignment
+  echo "Makefile:3: *** cannot assign to readonly variable: FOO"
+else
+  cat <<EOF > Makefile
+all: FOO :=$= bar
+FOO +=$= foo
+all: FOO +=$= baz
+all:
+EOF
+
+  ${mk} 2>&1 && echo "Clean exit"
+fi

--- a/var.cc
+++ b/var.cc
@@ -46,7 +46,7 @@ const char* GetOriginStr(VarOrigin origin) {
   return "*** broken origin ***";
 }
 
-Var::Var() : readonly_(false), message_(), error_(false) {}
+Var::Var() : message_(), readonly_(false), error_(false) {}
 
 Var::~Var() {}
 

--- a/var.h
+++ b/var.h
@@ -94,8 +94,8 @@ class Var : public Evaluable {
   Var();
 
  private:
-  bool readonly_;
   unique_ptr<string> message_;
+  bool readonly_;
   bool error_;
 };
 
@@ -162,7 +162,11 @@ extern UndefinedVar* kUndefined;
 
 class RuleVar : public Var {
  public:
-  RuleVar(Var* v, AssignOp op) : v_(v), op_(op) {}
+  RuleVar(Var* v, AssignOp op, bool readonly) : v_(v), op_(op) {
+    if (readonly) {
+      SetReadOnly();
+    }
+  }
   virtual ~RuleVar() { delete v_; }
 
   virtual const char* Flavor() const override { return v_->Flavor(); }


### PR DESCRIPTION
A variable cannot be assigned a new value after the final assignment.
The syntax of the final assignment is
`  <variable> =$=<value>`
or for the rule-specific variables it is
`  <target>: <variable> =$=<value>`
The effect is identical to having
`  .KATI_READONLY := <variable>`
or
`  <target>: .KATI_READONLY := variable`
that follows the assignment statement.
NOTE that if you still want to use `make`, please avoid having
whitespace after `=$=` (otherwise this whitespace will become
part of the variable's value).

Also, the change rearranges rule parsing and evaluation code.