### PR TITLE
Var and Value classes cleanup and memory footprint reduction.

### DIFF
--- a/command.cc
+++ b/command.cc
@@ -30,8 +30,8 @@ namespace {
 
 class AutoVar : public Var {
  public:
+  AutoVar() : Var(VarOrigin::AUTOMATIC) {}
   virtual const char* Flavor() const override { return "undefined"; }
-  virtual VarOrigin Origin() const override { return VarOrigin::AUTOMATIC; }
 
   virtual void AppendVar(Evaluator*, Value*) override { CHECK(false); }
 

--- a/dep.cc
+++ b/dep.cc
@@ -662,9 +662,9 @@ class DepBuilder {
     if (vars) {
       for (const auto& p : *vars) {
         Symbol name = p.first;
-        RuleVar* var = reinterpret_cast<RuleVar*>(p.second);
+        Var* var = p.second;
         CHECK(var);
-        Var* new_var = var->v();
+        Var* new_var = var;
         if (var->op() == AssignOp::PLUS_EQ) {
           Var* old_var = ev_->LookupVar(name);
           if (old_var->IsDefined()) {

--- a/eval.h
+++ b/eval.h
@@ -114,7 +114,7 @@ class Evaluator {
                Value* rhs,
                StringPiece orig_rhs,
                AssignOp op,
-               bool is_override = false);
+               bool is_override);
   void DoInclude(const string& fname);
 
   Var* LookupVarGlobal(Symbol name);

--- a/expr.h
+++ b/expr.h
@@ -37,10 +37,13 @@ class Evaluable {
 
 class Value : public Evaluable {
  public:
+  // All NewExpr calls take ownership of the Value instances.
+  static Value *NewExpr(Value *v1, Value *v2);
+  static Value *NewExpr(Value *v1, Value *v2, Value *v3);
+  static Value *NewExpr(vector<Value *> *values);
+
+  static Value *NewLiteral(StringPiece s);
   virtual ~Value();
-
-  virtual Value* Compact() { return this; }
-
   virtual bool IsLiteral() const { return false; }
   // Only safe after IsLiteral() returns true.
   virtual StringPiece GetLiteralValueUnsafe() const { return ""; }
@@ -70,10 +73,5 @@ Value* ParseExpr(const Loc& loc,
                  ParseExprOpt opt = ParseExprOpt::NORMAL);
 
 string JoinValues(const vector<Value*>& vals, const char* sep);
-
-Value* NewExpr2(Value* v1, Value* v2);
-Value* NewExpr3(Value* v1, Value* v2, Value* v3);
-
-Value* NewLiteral(StringPiece s);
 
 #endif  // EXPR_H_

--- a/main.cc
+++ b/main.cc
@@ -121,7 +121,7 @@ static void SetVar(StringPiece l, VarOrigin origin) {
   Symbol lhs = Intern(l.substr(0, found));
   StringPiece rhs = l.substr(found + 1);
   lhs.SetGlobalVar(
-      new RecursiveVar(NewLiteral(rhs.data()), origin, rhs.data()));
+      new RecursiveVar(Value::NewLiteral(rhs.data()), origin, rhs.data()));
 }
 
 extern "C" char** environ;

--- a/rule.cc
+++ b/rule.cc
@@ -51,7 +51,7 @@ void Rule::ParsePrerequisites(const StringPiece& line,
   if (separator_pos != string::npos && rule_stmt->sep != RuleStmt::SEP_SEMICOLON) {
     CHECK(line[separator_pos] == ';');
     // TODO: Maybe better to avoid Intern here?
-    cmds.push_back(NewLiteral(
+    cmds.push_back(Value::NewLiteral(
         Intern(TrimLeftSpace(line.substr(separator_pos + 1))).str()));
     prereq_string = line.substr(0, separator_pos);
   }

--- a/stmt.h
+++ b/stmt.h
@@ -27,7 +27,7 @@ using namespace std;
 class Evaluator;
 class Value;
 
-enum struct AssignOp {
+enum struct AssignOp : char {
   EQ,
   COLON_EQ,
   PLUS_EQ,

--- a/symtab.cc
+++ b/symtab.cc
@@ -30,7 +30,7 @@
 #include "var.h"
 
 struct SymbolData {
-  SymbolData() : gv(kUndefined) {}
+  SymbolData() : gv(Var::Undefined()) {}
 
   Var* gv;
 };
@@ -46,7 +46,7 @@ Symbol::Symbol(int v) : v_(v) {}
 
 Var* Symbol::PeekGlobalVar() const {
   if (static_cast<size_t>(v_) >= g_symbol_data.size()) {
-    return kUndefined;
+    return Var::Undefined();
   }
   return g_symbol_data[v_].gv;
 }


### PR DESCRIPTION
* Reduce Var instance size by moving the diagnostic message string to a
hash map for the instances that really have it (there are actually very
few such instances).
* Move common members from Var subclasses to the base class and
represent them more compactly.
* Remove RuleVar wrapper class, it is an extra object per rule-specific
variable.
* Rename Expr class to ValueList.
* Use additional constructors and convenience factory methods in Value
and its subclasses to avoid creating ValueList with a single element and
then compacting it.
* Use method overloading instead of having NewExpr2/NewExpr3, move them
for the global namespace to be factory methods of the Value class.