### PR TITLE
Fix deprecate/obsolete vars in ifdef/call

### DIFF
--- a/eval.cc
+++ b/eval.cc
@@ -373,6 +373,7 @@ void Evaluator::EvalIf(const IfStmt* stmt) {
       if (lhs.str().find_first_of(" \t") != string::npos)
         Error("*** invalid syntax in conditional.");
       Var* v = LookupVarInCurrentScope(lhs);
+      v->Used(this, lhs);
       is_true = (v->String().empty() == (stmt->op == CondOp::IFNDEF));
       break;
     }

--- a/func.cc
+++ b/func.cc
@@ -599,11 +599,12 @@ void CallFunc(const vector<Value*>& args, Evaluator* ev, string* s) {
 
   ev->CheckStack();
   const string&& func_name_buf = args[0]->Eval(ev);
-  const StringPiece func_name = TrimSpace(func_name_buf);
-  Var* func = ev->LookupVar(Intern(func_name));
+  Symbol func_sym = Intern(TrimSpace(func_name_buf));
+  Var* func = ev->LookupVar(func_sym);
+  func->Used(ev, func_sym);
   if (!func->IsDefined()) {
     KATI_WARN_LOC(ev->loc(), "*warning*: undefined user function: %s",
-                  func_name.as_string().c_str());
+                  func_sym.c_str());
   }
   vector<unique_ptr<SimpleVar>> av;
   for (size_t i = 1; i < args.size(); i++) {

--- a/testcase/deprecated_var.mk
+++ b/testcase/deprecated_var.mk
@@ -4,14 +4,14 @@
 A := test
 $(KATI_deprecated_var A B C D)
 
-# Writing to an undefined deprecated variable
+$(info Writing to an undefined deprecated variable)
 B := test
 ifndef KATI
 $(info Makefile:8: B has been deprecated.)
 endif
 
-# Reading from deprecated variables (set before/after/never the deprecation func)
-# Writing to an undefined deprecated variable
+$(info Reading from deprecated variables - set before/after/never the deprecation func)
+$(info Writing to an undefined deprecated variable)
 D := $(A)$(B)$(C)
 ifndef KATI
 $(info Makefile:15: A has been deprecated.)
@@ -20,27 +20,27 @@ $(info Makefile:15: C has been deprecated.)
 $(info Makefile:15: D has been deprecated.)
 endif
 
-# Writing to a reset deprecated variable
+$(info Writing to a reset deprecated variable)
 D += test
 ifndef KATI
 $(info Makefile:24: D has been deprecated.)
 endif
 
-# Using a custom message
+$(info Using a custom message)
 $(KATI_deprecated_var E,Use X instead)
 E = $(C)
 ifndef KATI
 $(info Makefile:31: E has been deprecated. Use X instead.)
 endif
 
-# Expanding a recursive variable with an embedded deprecated variable
+$(info Expanding a recursive variable with an embedded deprecated variable)
 $(E)
 ifndef KATI
 $(info Makefile:37: E has been deprecated. Use X instead.)
 $(info Makefile:37: C has been deprecated.)
 endif
 
-# All of the previous variable references have been basic SymRefs, now check VarRefs
+$(info All of the previous variable references have been basic SymRefs, now check VarRefs)
 F = E
 G := $($(F))
 ifndef KATI
@@ -48,13 +48,13 @@ $(info Makefile:45: E has been deprecated. Use X instead.)
 $(info Makefile:45: C has been deprecated.)
 endif
 
-# And check VarSubst
+$(info And check VarSubst)
 G := $(C:%.o=%.c)
 ifndef KATI
 $(info Makefile:52: C has been deprecated.)
 endif
 
-# Deprecated variable used in a rule-specific variable
+$(info Deprecated variable used in a rule-specific variable)
 test: A := $(E)
 ifndef KATI
 $(info Makefile:58: E has been deprecated. Use X instead.)
@@ -62,9 +62,23 @@ $(info Makefile:58: C has been deprecated.)
 # A hides the global A variable, so is not considered deprecated.
 endif
 
-# Deprecated variable used in a rule
+$(info Deprecated variable used as a macro)
+A := $(call B)
+ifndef KATI
+$(info Makefile:66: B has been deprecated.)
+$(info Makefile:66: A has been deprecated.)
+endif
+
+$(info Deprecated variable used in an ifdef)
+ifdef C
+endif
+ifndef KATI
+$(info Makefile:73: C has been deprecated.)
+endif
+
+$(info Deprecated variable used in a rule)
 test:
 	echo $(C)Done
 ifndef KATI
-$(info Makefile:67: C has been deprecated.)
+$(info Makefile:81: C has been deprecated.)
 endif


### PR DESCRIPTION
We hadn't been checking variables that were used in ifdef/ifndef or $(call) to see if they were deprecated.