### PR TITLE
Add --no_ninja_prelude

### DIFF
--- a/flags.cc
+++ b/flags.cc
@@ -102,6 +102,8 @@ void Flags::Parse(int argc, char** argv) {
       color_warnings = true;
     } else if (!strcmp(arg, "--no_builtin_rules")) {
       no_builtin_rules = true;
+    } else if (!strcmp(arg, "--no_ninja_prelude")) {
+      no_ninja_prelude = true;
     } else if (!strcmp(arg, "--werror_find_emulator")) {
       werror_find_emulator = true;
     } else if (!strcmp(arg, "--werror_overriding_commands")) {

--- a/flags.h
+++ b/flags.h
@@ -41,6 +41,7 @@ struct Flags {
   bool use_find_emulator;
   bool color_warnings;
   bool no_builtin_rules;
+  bool no_ninja_prelude;
   bool werror_find_emulator;
   bool werror_overriding_commands;
   bool warn_implicit_rules;

--- a/ninja.cc
+++ b/ninja.cc
@@ -600,14 +600,16 @@ class NinjaGenerator {
       fprintf(fp_, "\n");
     }
 
-    if (g_flags.ninja_dir) {
-      fprintf(fp_, "builddir = %s\n\n", g_flags.ninja_dir);
+    if (!g_flags.no_ninja_prelude) {
+      if (g_flags.ninja_dir) {
+        fprintf(fp_, "builddir = %s\n\n", g_flags.ninja_dir);
+      }
+
+      fprintf(fp_, "pool local_pool\n");
+      fprintf(fp_, " depth = %d\n\n", g_flags.num_jobs);
+
+      fprintf(fp_, "build _kati_always_build_: phony\n\n");
     }
-
-    fprintf(fp_, "pool local_pool\n");
-    fprintf(fp_, " depth = %d\n\n", g_flags.num_jobs);
-
-    fprintf(fp_, "build _kati_always_build_: phony\n\n");
 
     unique_ptr<ThreadPool> tp(NewThreadPool(g_flags.num_jobs));
     CHECK(g_flags.num_jobs);


### PR DESCRIPTION
This argument will remove the common bits at the beginning of the ninja file -- `build_dir`, `local_pool`, and `_kati_always_build_`. It's most useful so that Kati can be run twice, with the output ninja files combined into a single ninja execution.

It also lets us change the local_pool size without having to re-read all the makefiles.