### PR TITLE
Mark fallthrough cases with [[clang::fallthrough]]

### DIFF
--- a/func.cc
+++ b/func.cc
@@ -64,7 +64,9 @@ void StripShellComment(string* cmd) {
             in++;
           break;
         }
-        /* FALLTHRU */
+#if defined(__has_cpp_attribute) && __has_cpp_attribute(clang::fallthrough)
+	[[clang::fallthrough]];
+#endif
 
       case '\'':
       case '"':

--- a/ninja.cc
+++ b/ninja.cc
@@ -530,7 +530,9 @@ class NinjaGenerator {
         case ':':
         case ' ':
           r += '$';
-        // fall through.
+#if defined(__has_cpp_attribute) && __has_cpp_attribute(clang::fallthrough)
+          [[clang::fallthrough]];
+#endif
         default:
           r += c;
       }


### PR DESCRIPTION
That way they don't cause warnings when -Wimplicit-fallthrough is enabled in clang.