### PR TITLE
SetAffinityForMultiThread before execve.

### DIFF
--- a/fileutil.cc
+++ b/fileutil.cc
@@ -31,6 +31,7 @@
 
 #include <unordered_map>
 
+#include "affinity.h"
 #include "log.h"
 #include "strutil.h"
 
@@ -125,6 +126,7 @@ int RunCommand(const string& shell,
       PERROR("dup2 failed");
     close(pipefd[1]);
 
+    SetAffinityForMultiThread();
     execvp(argv[0], const_cast<char**>(argv));
     PLOG("execvp for %s failed", argv[0]);
     kill(getppid(), SIGTERM);

--- a/fileutil.cc
+++ b/fileutil.cc
@@ -126,7 +126,10 @@ int RunCommand(const string& shell,
       PERROR("dup2 failed");
     close(pipefd[1]);
 
-    SetAffinityForMultiThread();
+    if (cmd.find("/goma_ctl.py") != string::npos) {
+      // Set multi thread affinity for Goma.
+      SetAffinityForMultiThread();
+    }
     execvp(argv[0], const_cast<char**>(argv));
     PLOG("execvp for %s failed", argv[0]);
     kill(getppid(), SIGTERM);


### PR DESCRIPTION
ckati limit the number of CPU cores to be used with
SetAffinityForSingleThread at the beginning of the program.
Since it affects program invoked by ckati, child processes are
executed with unexpectedly small number of CPUs.
Let me SetAffinityForMultiThread before execve to reset that.

Since Goma compiler_proxy is invoked by ckati on Android, it limit
the number of CPUs used for compiler_proxy's local compiler run.