### PR TITLE
Add --empty_ninja_file for test usecases

### DIFF
--- a/flags.cc
+++ b/flags.cc
@@ -82,6 +82,8 @@ void Flags::Parse(int argc, char** argv) {
       enable_kati_warnings = true;
     } else if (!strcmp(arg, "--ninja")) {
       generate_ninja = true;
+    } else if (!strcmp(arg, "--empty_ninja_file")) {
+      generate_empty_ninja = true;
     } else if (!strcmp(arg, "--gen_all_targets")) {
       gen_all_targets = true;
     } else if (!strcmp(arg, "--regen")) {

--- a/flags.h
+++ b/flags.h
@@ -32,6 +32,7 @@ struct Flags {
   bool enable_stat_logs;
   bool gen_all_targets;
   bool generate_ninja;
+  bool generate_empty_ninja;
   bool is_dry_run;
   bool is_silent_mode;
   bool is_syntax_check_only;

--- a/ninja.cc
+++ b/ninja.cc
@@ -629,8 +629,10 @@ class NinjaGenerator {
     }
     tp->Wait();
 
-    for (const ostringstream& buf : bufs) {
-      fprintf(fp_, "%s", buf.str().c_str());
+    if (!g_flags.generate_empty_ninja) {
+      for (const ostringstream& buf : bufs) {
+        fprintf(fp_, "%s", buf.str().c_str());
+      }
     }
 
     SymbolSet used_env_vars(Vars::used_env_vars());
@@ -652,8 +654,10 @@ class NinjaGenerator {
         default_targets += EscapeBuildTarget(s);
       }
     }
-    fprintf(fp_, "\n");
-    fprintf(fp_, "default %s\n", default_targets.c_str());
+    if (!g_flags.generate_empty_ninja) {
+      fprintf(fp_, "\n");
+      fprintf(fp_, "default %s\n", default_targets.c_str());
+    }
 
     fclose(fp_);
   }


### PR DESCRIPTION
In cases that we want to run Kati in many configurations to verify all of the generation logic works without errors, but don't care about running the final ninja file, writing it out only wastes time. So add a --empty_ninja_file option that skips writing out build rules and defaults information, leading to a very small ninja file.

Our specific use case (Soong's build_test / multiproduct_kati) runs Kati several hundred times for different configurations, and the ninja files are around 750MB. Even when we truncate them immediately after writing, that still leads to hundreds of gigabytes of writes to disk.