### PR TITLE
Improve regen performance by setting cpu affinity

### DIFF
--- a/regen.cc
+++ b/regen.cc
@@ -23,6 +23,7 @@
 #include <mutex>
 #include <vector>
 
+#include "affinity.h"
 #include "fileutil.h"
 #include "find.h"
 #include "func.h"
@@ -429,6 +430,7 @@ class StampChecker {
     tp->Submit([this]() {
       string err;
       // TODO: Make glob cache thread safe and create a task for each glob.
+      SetAffinityForSingleThread();
       for (GlobResult* gr : globs_) {
         if (CheckGlobResult(gr, &err)) {
           unique_lock<mutex> lock(mu_);
@@ -442,6 +444,7 @@ class StampChecker {
     });
 
     tp->Submit([this]() {
+      SetAffinityForSingleThread();
       for (ShellResult* sr : commands_) {
         string err;
         if (CheckShellResult(sr, &err)) {


### PR DESCRIPTION
For aosp/master aosp_arm64-eng, this brings the times for regen down by nearly a second:

```
glob time (regen)  0.52 -> 0.52
shell time (regen) 2.25 -> 1.39
stat time (regen)  0.54 -> 0.44
```

Some of our internal targets show larger decreases:

```
glob time (regen)  0.81 -> 0.83
shell time (regen) 4.84 -> 2.99
stat time (regen)  1.11 -> 0.95
```