### PR TITLE
Run clang-format, then enforce it via Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,16 +6,27 @@ sudo: required
 compiler:
   - clang
 
+addons:
+  apt:
+    update: true
+    sources:
+      - ubuntu-toolchain-r-test
+      - llvm-toolchain-trusty-7
+    packages:
+      - clang-7
+      - clang-format-7
+      - realpath
+
 cache: apt
 
 before_script:
-  - sudo apt-get update -qq
-  - sudo apt-get install -y realpath
   - wget https://github.com/ninja-build/ninja/releases/download/v1.7.2/ninja-linux.zip
   - unzip ninja-linux.zip -d ~/bin
 
 script:
+  - export CXX=clang++-7
   - make -j4 ckati ckati_tests
+  - ./clang-format-check
   - ruby runtest.rb -c
   - ruby runtest.rb -c -n
   - ruby runtest.rb -c -n -a

--- a/clang-format-check
+++ b/clang-format-check
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+CLANG_FORMAT="clang-format-7"
+if [ -z "$(which $CLANG_FORMAT)" ]; then
+  CLANG_FORMAT="clang-format"
+fi
+
+for f in $(ls *.cc *.h); do
+  if ! diff -U 1 <($CLANG_FORMAT $f) $f; then
+    echo
+    echo "!!!!!!"
+    echo "!! Failed clang-format check, please run 'clang-format -i *.cc *.h'" 1>&2
+    echo "!!!!!!"
+    exit 1
+  fi
+done

--- a/dep.cc
+++ b/dep.cc
@@ -148,9 +148,7 @@ struct RuleMerger {
   bool is_double_colon;
 
   RuleMerger()
-      : primary_rule(nullptr),
-        parent(nullptr),
-        is_double_colon(false) {}
+      : primary_rule(nullptr), parent(nullptr), is_double_colon(false) {}
 
   void AddImplicitOutput(Symbol output, RuleMerger* merger) {
     implicit_outputs.push_back(make_pair(output, merger));
@@ -370,7 +368,7 @@ class DepBuilder {
       cur_rule_vars_.reset(new Vars);
       ev_->set_current_scope(cur_rule_vars_.get());
       DepNode* n = BuildPlan(target, Intern(""));
-      nodes->push_back({target,n});
+      nodes->push_back({target, n});
       ev_->set_current_scope(NULL);
       cur_rule_vars_.reset(NULL);
     }
@@ -785,7 +783,7 @@ class DepBuilder {
 
     for (Symbol input : n->actual_order_only_inputs) {
       DepNode* c = BuildPlan(input, output);
-      n->order_onlys.push_back({input,c});
+      n->order_onlys.push_back({input, c});
     }
 
     n->has_rule = true;

--- a/dep.h
+++ b/dep.h
@@ -29,7 +29,7 @@ class Value;
 class Var;
 class Vars;
 
-typedef pair<Symbol,struct DepNode *> NamedDepNode;
+typedef pair<Symbol, struct DepNode*> NamedDepNode;
 
 struct DepNode {
   DepNode(Symbol output, bool is_phony, bool is_restat);

--- a/eval.cc
+++ b/eval.cc
@@ -65,7 +65,7 @@ Var* Evaluator::EvalRHS(Symbol lhs,
                         StringPiece orig_rhs,
                         AssignOp op,
                         bool is_override,
-                        bool *needs_assign) {
+                        bool* needs_assign) {
   VarOrigin origin =
       ((is_bootstrap_ ? VarOrigin::DEFAULT
                       : is_commandline_ ? VarOrigin::COMMAND_LINE
@@ -145,9 +145,9 @@ void Evaluator::EvalAssign(const AssignStmt* stmt) {
   }
 
   bool needs_assign;
-  Var* var = EvalRHS(lhs, stmt->rhs, stmt->orig_rhs, stmt->op,
-                     stmt->directive == AssignDirective::OVERRIDE,
-                     &needs_assign);
+  Var* var =
+      EvalRHS(lhs, stmt->rhs, stmt->orig_rhs, stmt->op,
+              stmt->directive == AssignDirective::OVERRIDE, &needs_assign);
   if (needs_assign) {
     bool readonly;
     lhs.SetGlobalVar(var, stmt->directive == AssignDirective::OVERRIDE,
@@ -192,7 +192,6 @@ static StringPiece ParseRuleTargets(const Loc& loc,
   return before_term.substr(pos + 1);
 }
 
-
 void Evaluator::MarkVarsReadonly(Value* vars_list) {
   string vars_list_string;
   vars_list->Eval(this, &vars_list_string);
@@ -227,8 +226,8 @@ void Evaluator::EvalRuleSpecificAssign(const vector<Symbol>& targets,
       rhs = stmt->rhs;
     } else if (stmt->rhs) {
       StringPiece sep(stmt->sep == RuleStmt::SEP_SEMICOLON ? " ; " : " = ");
-      rhs = Value::NewExpr(Value::NewLiteral(rhs_string), Value::NewLiteral(sep),
-                           stmt->rhs);
+      rhs = Value::NewExpr(Value::NewLiteral(rhs_string),
+                           Value::NewLiteral(sep), stmt->rhs);
     } else {
       rhs = Value::NewLiteral(rhs_string);
     }
@@ -238,7 +237,8 @@ void Evaluator::EvalRuleSpecificAssign(const vector<Symbol>& targets,
       MarkVarsReadonly(rhs);
     } else {
       bool needs_assign;
-      Var* rhs_var = EvalRHS(var_sym, rhs, StringPiece("*TODO*"), assign_op, false, &needs_assign);
+      Var* rhs_var = EvalRHS(var_sym, rhs, StringPiece("*TODO*"), assign_op,
+                             false, &needs_assign);
       if (needs_assign) {
         bool readonly;
         rhs_var->SetAssignOp(assign_op);
@@ -286,7 +286,8 @@ void Evaluator::EvalRule(const RuleStmt* stmt) {
   if (separator_pos != string::npos) {
     separator = after_targets[separator_pos];
   } else if (separator_pos == string::npos &&
-             (stmt->sep == RuleStmt::SEP_EQ || stmt->sep == RuleStmt::SEP_FINALEQ)) {
+             (stmt->sep == RuleStmt::SEP_EQ ||
+              stmt->sep == RuleStmt::SEP_FINALEQ)) {
     separator_pos = after_targets.size();
     separator = '=';
   }
@@ -309,7 +310,8 @@ void Evaluator::EvalRule(const RuleStmt* stmt) {
     buf = after_targets.as_string();
     if (stmt->sep == RuleStmt::SEP_SEMICOLON) {
       buf += ';';
-    } else if (stmt->sep == RuleStmt::SEP_EQ || stmt->sep == RuleStmt::SEP_FINALEQ) {
+    } else if (stmt->sep == RuleStmt::SEP_EQ ||
+               stmt->sep == RuleStmt::SEP_FINALEQ) {
       buf += '=';
     }
     if (stmt->rhs) {
@@ -410,7 +412,8 @@ void Evaluator::DoInclude(const string& fname) {
   }
 
   Var* var_list = LookupVar(Intern("MAKEFILE_LIST"));
-  var_list->AppendVar(this, Value::NewLiteral(Intern(TrimLeadingCurdir(fname)).str()));
+  var_list->AppendVar(
+      this, Value::NewLiteral(Intern(TrimLeadingCurdir(fname)).str()));
   for (Stmt* stmt : mk->stmts()) {
     LOG("%s", stmt->DebugString().c_str());
     stmt->Eval(this);

--- a/eval.h
+++ b/eval.h
@@ -78,9 +78,7 @@ class Evaluator {
   }
   void clear_delayed_output_commands() { delayed_output_commands_.clear(); }
 
-  static const SymbolSet& used_undefined_vars() {
-    return used_undefined_vars_;
-  }
+  static const SymbolSet& used_undefined_vars() { return used_undefined_vars_; }
 
   int eval_depth() const { return eval_depth_; }
   void IncrementEvalDepth() { eval_depth_++; }
@@ -115,7 +113,7 @@ class Evaluator {
                StringPiece orig_rhs,
                AssignOp op,
                bool is_override,
-               bool *needs_assign);
+               bool* needs_assign);
   void DoInclude(const string& fname);
 
   Var* LookupVarGlobal(Symbol name);
@@ -123,11 +121,12 @@ class Evaluator {
   // Equivalent to LookupVarInCurrentScope, but doesn't mark as used.
   Var* PeekVarInCurrentScope(Symbol name);
 
-  void MarkVarsReadonly(Value *var_list);
+  void MarkVarsReadonly(Value* var_list);
 
   void EvalRuleSpecificAssign(const vector<Symbol>& targets,
-                              const RuleStmt *stmt,
-                              const StringPiece& lhs_string, size_t separator_pos);
+                              const RuleStmt* stmt,
+                              const StringPiece& lhs_string,
+                              size_t separator_pos);
 
   unordered_map<Symbol, Vars*> rule_vars_;
   vector<const Rule*> rules_;

--- a/exec.cc
+++ b/exec.cc
@@ -144,7 +144,7 @@ void Exec(const vector<NamedDepNode>& roots, Evaluator* ev) {
     executor->ExecNode(root.second, NULL);
   }
   if (executor->Count() == 0) {
-    for (auto const & root : roots) {
+    for (auto const& root : roots) {
       printf("kati: Nothing to be done for `%s'.\n", root.first.c_str());
     }
   }

--- a/expr.cc
+++ b/expr.cc
@@ -39,7 +39,7 @@ Value::Value() {}
 
 Value::~Value() {}
 
-string Value::DebugString(const Value *v) {
+string Value::DebugString(const Value* v) {
   return v ? NoLineBreak(v->DebugString_()) : "(null)";
 }
 
@@ -67,26 +67,23 @@ class ValueList : public Value {
  public:
   ValueList() {}
 
-  ValueList(Value *v1, Value *v2, Value *v3)
-      :ValueList(){
+  ValueList(Value* v1, Value* v2, Value* v3) : ValueList() {
     vals_.reserve(3);
     vals_.push_back(v1);
     vals_.push_back(v2);
     vals_.push_back(v3);
   }
 
-  ValueList(Value *v1, Value *v2):
-      ValueList() {
+  ValueList(Value* v1, Value* v2) : ValueList() {
     vals_.reserve(2);
     vals_.push_back(v1);
     vals_.push_back(v2);
   }
 
-  ValueList(vector<Value *> *values):ValueList() {
+  ValueList(vector<Value*>* values) : ValueList() {
     values->shrink_to_fit();
     values->swap(vals_);
   }
-
 
   virtual ~ValueList() {
     for (Value* v : vals_) {
@@ -274,9 +271,9 @@ Value* Value::NewExpr(Value* v1, Value* v2, Value* v3) {
   return new ValueList(v1, v2, v3);
 }
 
-Value* Value::NewExpr(vector<Value *> *values) {
+Value* Value::NewExpr(vector<Value*>* values) {
   if (values->size() == 1) {
-    Value *v = (*values)[0];
+    Value* v = (*values)[0];
     values->clear();
     return v;
   }
@@ -462,7 +459,7 @@ Value* ParseExprImpl(const Loc& loc,
   char save_paren = 0;
   int paren_depth = 0;
   size_t i;
-  vector<Value *> list;
+  vector<Value*> list;
   for (i = 0; i < s.size(); i++) {
     char c = s[i];
     if (terms && strchr(terms, c) && !save_paren) {

--- a/expr.h
+++ b/expr.h
@@ -38,17 +38,17 @@ class Evaluable {
 class Value : public Evaluable {
  public:
   // All NewExpr calls take ownership of the Value instances.
-  static Value *NewExpr(Value *v1, Value *v2);
-  static Value *NewExpr(Value *v1, Value *v2, Value *v3);
-  static Value *NewExpr(vector<Value *> *values);
+  static Value* NewExpr(Value* v1, Value* v2);
+  static Value* NewExpr(Value* v1, Value* v2, Value* v3);
+  static Value* NewExpr(vector<Value*>* values);
 
-  static Value *NewLiteral(StringPiece s);
+  static Value* NewLiteral(StringPiece s);
   virtual ~Value();
   virtual bool IsLiteral() const { return false; }
   // Only safe after IsLiteral() returns true.
   virtual StringPiece GetLiteralValueUnsafe() const { return ""; }
 
-  static string DebugString(const Value *);
+  static string DebugString(const Value*);
 
  protected:
   Value();

--- a/func.cc
+++ b/func.cc
@@ -65,7 +65,7 @@ void StripShellComment(string* cmd) {
           break;
         }
 #if defined(__has_cpp_attribute) && __has_cpp_attribute(clang::fallthrough)
-	[[clang::fallthrough]];
+        [[clang::fallthrough]];
 #endif
 
       case '\'':

--- a/ninja.h
+++ b/ninja.h
@@ -20,8 +20,8 @@
 #include <string>
 #include <vector>
 
-#include "string_piece.h"
 #include "dep.h"
+#include "string_piece.h"
 
 using namespace std;
 

--- a/parser.cc
+++ b/parser.cc
@@ -231,15 +231,17 @@ class Parser {
       if (line[found] == ';') {
         rule_stmt->sep = RuleStmt::SEP_SEMICOLON;
       } else if (line[found] == '=') {
-        if (line.size() > (found + 2) && line[found + 1] == '$' && line[found + 2] == '=') {
+        if (line.size() > (found + 2) && line[found + 1] == '$' &&
+            line[found + 2] == '=') {
           rule_stmt->sep = RuleStmt::SEP_FINALEQ;
           found += 2;
         } else {
           rule_stmt->sep = RuleStmt::SEP_EQ;
         }
       }
-      ParseExprOpt opt =
-          rule_stmt->sep == RuleStmt::SEP_SEMICOLON ? ParseExprOpt::COMMAND : ParseExprOpt::NORMAL;
+      ParseExprOpt opt = rule_stmt->sep == RuleStmt::SEP_SEMICOLON
+                             ? ParseExprOpt::COMMAND
+                             : ParseExprOpt::NORMAL;
       rule_stmt->rhs = ParseExpr(TrimLeftSpace(line.substr(found + 1)), opt);
     } else {
       rule_stmt->lhs = ParseExpr(line);

--- a/rule.cc
+++ b/rule.cc
@@ -25,8 +25,7 @@
 
 Rule::Rule() : is_double_colon(false), is_suffix_rule(false), cmd_lineno(0) {}
 
-
-void Rule::ParseInputs(const StringPiece &inputs_str) {
+void Rule::ParseInputs(const StringPiece& inputs_str) {
   bool is_order_only = false;
   for (auto const& input : WordScanner(inputs_str)) {
     if (input == "|") {
@@ -40,7 +39,7 @@ void Rule::ParseInputs(const StringPiece &inputs_str) {
 
 void Rule::ParsePrerequisites(const StringPiece& line,
                               size_t separator_pos,
-                              const RuleStmt *rule_stmt) {
+                              const RuleStmt* rule_stmt) {
   // line is either
   //    prerequisites [ ; command ]
   // or
@@ -48,7 +47,8 @@ void Rule::ParsePrerequisites(const StringPiece& line,
   // First, separate command. At this point separator_pos should point to ';'
   // unless null.
   StringPiece prereq_string = line;
-  if (separator_pos != string::npos && rule_stmt->sep != RuleStmt::SEP_SEMICOLON) {
+  if (separator_pos != string::npos &&
+      rule_stmt->sep != RuleStmt::SEP_SEMICOLON) {
     CHECK(line[separator_pos] == ';');
     // TODO: Maybe better to avoid Intern here?
     cmds.push_back(Value::NewLiteral(

--- a/rule.h
+++ b/rule.h
@@ -61,5 +61,4 @@ class Rule {
   void Error(const string& msg) { ERROR_LOC(loc, "%s", msg.c_str()); }
 };
 
-
 #endif  // RULE_H_

--- a/stmt.cc
+++ b/stmt.cc
@@ -80,8 +80,8 @@ Symbol AssignStmt::GetLhsSymbol(Evaluator* ev) const {
 }
 
 string CommandStmt::DebugString() const {
-  return StringPrintf("CommandStmt(%s, loc=%s:%d)", Value::DebugString(expr).c_str(),
-                      LOCF(loc()));
+  return StringPrintf("CommandStmt(%s, loc=%s:%d)",
+                      Value::DebugString(expr).c_str(), LOCF(loc()));
 }
 
 string IfStmt::DebugString() const {
@@ -107,8 +107,8 @@ string IfStmt::DebugString() const {
 }
 
 string IncludeStmt::DebugString() const {
-  return StringPrintf("IncludeStmt(%s, loc=%s:%d)", Value::DebugString(expr).c_str(),
-                      LOCF(loc()));
+  return StringPrintf("IncludeStmt(%s, loc=%s:%d)",
+                      Value::DebugString(expr).c_str(), LOCF(loc()));
 }
 
 string ExportStmt::DebugString() const {

--- a/symtab.h
+++ b/symtab.h
@@ -67,13 +67,13 @@ class Symbol {
 /* A set of symbols represented as bitmap indexed by Symbol's ordinal value. */
 class SymbolSet {
  public:
-  SymbolSet():low_(0), high_(0) {}
+  SymbolSet() : low_(0), high_(0) {}
 
   /* Returns true if Symbol belongs to this set. */
   bool exists(Symbol sym) const {
     size_t bit_nr = static_cast<size_t>(sym.val());
     return sym.IsValid() && bit_nr >= low_ && bit_nr < high_ &&
-        bits_[(bit_nr - low_) / 64][(bit_nr - low_) % 64];
+           bits_[(bit_nr - low_) / 64][(bit_nr - low_) % 64];
   }
 
   /* Adds Symbol to this set.  */
@@ -83,7 +83,7 @@ class SymbolSet {
     }
     size_t bit_nr = static_cast<size_t>(sym.val());
     if (bit_nr < low_ || bit_nr >= high_) {
-        resize(bit_nr);
+      resize(bit_nr);
     }
     bits_[(bit_nr - low_) / 64][(bit_nr - low_) % 64] = true;
   }
@@ -107,8 +107,7 @@ class SymbolSet {
     size_t pos_;
 
     iterator(const SymbolSet* bitset, size_t pos)
-        :bitset_(bitset), pos_(pos) {
-    }
+        : bitset_(bitset), pos_(pos) {}
 
     /* Proceed to the next Symbol.  */
     void next() {
@@ -139,11 +138,9 @@ class SymbolSet {
       return bitset_ == other.bitset_ && pos_ == other.pos_;
     }
 
-    bool operator!=(iterator other) const {
-      return !(*this == other);
-    }
+    bool operator!=(iterator other) const { return !(*this == other); }
 
-    Symbol operator*() {return Symbol(pos_); }
+    Symbol operator*() { return Symbol(pos_); }
 
     friend class SymbolSet;
   };
@@ -154,9 +151,7 @@ class SymbolSet {
     return it;
   }
 
-  iterator end() const {
-    return iterator(this, high_);
-  }
+  iterator end() const { return iterator(this, high_); }
 
  private:
   friend class iterator;
@@ -177,8 +172,9 @@ class SymbolSet {
     if (new_low == low_) {
       bits_.resize((new_high - new_low) / 64);
     } else {
-      std::vector<std::bitset<64> > newbits((new_high - new_low)/64);
-      std::copy(bits_.begin(), bits_.end(), newbits.begin() + (low_ - new_low) / 64);
+      std::vector<std::bitset<64> > newbits((new_high - new_low) / 64);
+      std::copy(bits_.begin(), bits_.end(),
+                newbits.begin() + (low_ - new_low) / 64);
       bits_.swap(newbits);
     }
     low_ = new_low;

--- a/var.cc
+++ b/var.cc
@@ -20,7 +20,7 @@
 #include "expr.h"
 #include "log.h"
 
-unordered_map<const Var *, string> Var::diagnostic_messages_;
+unordered_map<const Var*, string> Var::diagnostic_messages_;
 
 const char* GetOriginStr(VarOrigin origin) {
   switch (origin) {
@@ -47,9 +47,8 @@ const char* GetOriginStr(VarOrigin origin) {
 
 Var::Var() : Var(VarOrigin::UNDEFINED) {}
 
-Var::Var(VarOrigin origin):
-    origin_(origin), readonly_(false), deprecated_(false), obsolete_(false) {
-}
+Var::Var(VarOrigin origin)
+    : origin_(origin), readonly_(false), deprecated_(false), obsolete_(false) {}
 
 Var::~Var() {
   diagnostic_messages_.erase(this);
@@ -69,16 +68,17 @@ void Var::SetObsolete(const StringPiece& msg) {
   diagnostic_messages_[this] = msg.as_string();
 }
 
-
 void Var::Used(Evaluator* ev, const Symbol& sym) const {
   if (obsolete_) {
-    ev->Error(StringPrintf("*** %s is obsolete%s.", sym.c_str(), diagnostic_message_text()));
+    ev->Error(StringPrintf("*** %s is obsolete%s.", sym.c_str(),
+                           diagnostic_message_text()));
   } else if (deprecated_) {
-    WARN_LOC(ev->loc(), "%s has been deprecated%s.", sym.c_str(), diagnostic_message_text());
+    WARN_LOC(ev->loc(), "%s has been deprecated%s.", sym.c_str(),
+             diagnostic_message_text());
   }
 }
 
-const char *Var::diagnostic_message_text() const {
+const char* Var::diagnostic_message_text() const {
   auto it = diagnostic_messages_.find(this);
   return it == diagnostic_messages_.end() ? "" : it->second.c_str();
 }
@@ -89,8 +89,8 @@ const string& Var::DeprecatedMessage() const {
   return it == diagnostic_messages_.end() ? empty_string : it->second;
 }
 
-Var *Var::Undefined() {
-  static Var *undefined_var;
+Var* Var::Undefined() {
+  static Var* undefined_var;
   if (!undefined_var) {
     undefined_var = new UndefinedVar();
   }
@@ -99,11 +99,9 @@ Var *Var::Undefined() {
 
 SimpleVar::SimpleVar(VarOrigin origin) : Var(origin) {}
 
-SimpleVar::SimpleVar(const string& v, VarOrigin origin)
-    : Var(origin), v_(v) {}
+SimpleVar::SimpleVar(const string& v, VarOrigin origin) : Var(origin), v_(v) {}
 
-SimpleVar::SimpleVar(VarOrigin origin, Evaluator* ev, Value* v)
-    : Var(origin) {
+SimpleVar::SimpleVar(VarOrigin origin, Evaluator* ev, Value* v) : Var(origin) {
   v->Eval(ev, &v_);
 }
 

--- a/var.h
+++ b/var.h
@@ -77,7 +77,7 @@ class Var : public Evaluable {
   AssignOp op() const { return assign_op_; }
   void SetAssignOp(AssignOp op) { assign_op_ = op; }
 
-  static Var *Undefined();
+  static Var* Undefined();
 
  protected:
   Var();
@@ -86,13 +86,13 @@ class Var : public Evaluable {
  private:
   const VarOrigin origin_;
   AssignOp assign_op_;
-  bool readonly_:1;
-  bool deprecated_:1;
-  bool obsolete_:1;
+  bool readonly_ : 1;
+  bool deprecated_ : 1;
+  bool obsolete_ : 1;
 
-  const char *diagnostic_message_text() const;
+  const char* diagnostic_message_text() const;
 
-  static unordered_map<const Var *, string> diagnostic_messages_;
+  static unordered_map<const Var*, string> diagnostic_messages_;
 };
 
 class SimpleVar : public Var {


### PR DESCRIPTION
As a by-product, update clang from the default 3.5 on Trusty to 7.

You can see what happens on error here: https://travis-ci.org/danw/kati/builds/451168535