### PR TITLE
Fix segfault when reporting implicit outputs error

### DIFF
--- a/dep.cc
+++ b/dep.cc
@@ -164,7 +164,7 @@ struct RuleMerger {
                 "*** implicit output `%s' of `%s' was already defined by `%s' "
                 "at %s:%d",
                 output.c_str(), p.c_str(), parent_sym.c_str(),
-                parent->primary_rule->cmd_loc());
+                LOCF(parent->primary_rule->cmd_loc()));
     }
     if (primary_rule) {
       ERROR_LOC(primary_rule->cmd_loc(),


### PR DESCRIPTION
The format expected the LOCF macro to convert a Loc object to %s:%d,
but was getting just the Loc object.

Change-Id: I64005aa0b23fe1f70292a3da543799c51fbdcdc9