### PR TITLE
Fix undeclared identifier 'exit' on Mac.

### DIFF
--- a/find_test.cc
+++ b/find_test.cc
@@ -16,6 +16,7 @@
 
 #include "find.h"
 
+#include <stdlib.h>
 #include <unistd.h>
 #include <string>
 


### PR DESCRIPTION
I compile kati error on mac.
error:
find_test.cc:61:5: error: use of undeclared identifier 'exit'; did you mean '_exit'?

So I add '#include <stdlib.h>' to work.