### PR TITLE
Use std::random_device instead of initializing via getpid

### DIFF
--- a/affinity.cc
+++ b/affinity.cc
@@ -30,7 +30,7 @@
 void SetAffinityForSingleThread() {
   cpu_set_t cs;
   CPU_ZERO(&cs);
-  std::default_random_engine generator(getpid());
+  std::random_device generator;
   std::uniform_int_distribution<int> distribution(0, g_flags.num_cpus - 1);
   int cpu = distribution(generator);
 


### PR DESCRIPTION
getpid worked fine for this until we started trying to run Kati within a pid namespace (via nsjail). Then it consistently got the same pid, which resulted in multiple copies of Kati all running on the same CPU.