### PR TITLE
Add --top_level_phony

### DIFF
--- a/dep.cc
+++ b/dep.cc
@@ -768,7 +768,11 @@ class DepBuilder {
       DepNode* c = BuildPlan(input, output);
       n->deps.push_back({input, c});
 
-      if (!n->is_phony && c->is_phony) {
+      bool is_phony = c->is_phony;
+      if (!is_phony && !c->has_rule && g_flags.top_level_phony) {
+        is_phony = input.str().find("/") == string::npos;
+      }
+      if (!n->is_phony && is_phony) {
         if (g_flags.werror_real_to_phony) {
           ERROR_LOC(n->loc,
                     "*** real file \"%s\" depends on PHONY target \"%s\"",

--- a/flags.cc
+++ b/flags.cc
@@ -118,6 +118,8 @@ void Flags::Parse(int argc, char** argv) {
       warn_suffix_rules = true;
     } else if (!strcmp(arg, "--werror_suffix_rules")) {
       werror_suffix_rules = true;
+    } else if (!strcmp(arg, "--top_level_phony")) {
+      top_level_phony = true;
     } else if (!strcmp(arg, "--warn_real_to_phony")) {
       warn_real_to_phony = true;
     } else if (!strcmp(arg, "--werror_real_to_phony")) {

--- a/flags.h
+++ b/flags.h
@@ -49,6 +49,7 @@ struct Flags {
   bool werror_implicit_rules;
   bool warn_suffix_rules;
   bool werror_suffix_rules;
+  bool top_level_phony;
   bool warn_real_to_phony;
   bool werror_real_to_phony;
   bool warn_phony_looks_real;

--- a/testcase/top_level_phony.sh
+++ b/testcase/top_level_phony.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+#
+# Copyright 2018 Google Inc. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -u
+
+mk="$@"
+
+cat <<EOF > Makefile
+.PHONY: test
+test: out/foo
+out/foo: bar
+	@echo "END"
+EOF
+
+touch bar
+
+if echo "${mk}" | grep -qv "kati"; then
+  # Make doesn't support these warnings, so write the expected output.
+  echo 'Makefile:4: warning: real file "out/foo" depends on PHONY target "bar"'
+  echo 'END'
+else
+  ${mk} --warn_real_to_phony --top_level_phony 2>&1
+fi
+
+if echo "${mk}" | grep -qv "kati"; then
+  # Make doesn't support these warnings, so write the expected output.
+  echo 'Makefile:4: *** real file "out/foo" depends on PHONY target "bar"'
+else
+  ${mk} --werror_real_to_phony --top_level_phony 2>&1
+fi


### PR DESCRIPTION
This makes the real_to_phony checks assume that any leaf dependencies that doesn't have a '/' in it is a PHONY target.

We need this in Android since we now have two separate Kati instances both writing out ninja files from Makefiles. Without this, the real_to_phony checks don't work when the PHONY target is defined in the other Kati instance.