### PR TITLE
Fix 32-bit builds; only build 64-bit in Android trees

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -20,6 +20,7 @@ cc_defaults {
         "-Werror",
         "-DNOLOG",
     ],
+    compile_multilib: "64",
     tidy_checks: [
         "-google-global-names-in-headers",
         "-google-build-using-namespace",

--- a/stats.cc
+++ b/stats.cc
@@ -51,7 +51,7 @@ void Stats::DumpTop() const {
          });
 
     // Only print the top 10
-    details.resize(min(details.size(), 10LU));
+    details.resize(min(details.size(), static_cast<size_t>(10)));
 
     if (!interesting_.empty()) {
       // No need to print anything out twice


### PR DESCRIPTION
We really only need the 64-bit build, but checkbuild & mma was building the 32-bit versions of libckati.

It was also easy enough to fix the 32-bit build break, so I did that as well.