### PR TITLE
Refine check for special targets and suffix rules

### DIFF
--- a/dep.cc
+++ b/dep.cc
@@ -126,7 +126,7 @@ class RuleTrie {
 };
 
 bool IsSuffixRule(Symbol output) {
-  if (output.empty() || output.str()[0] != '.')
+  if (output.empty() || !IsSpecialTarget(output))
     return false;
   const StringPiece rest = StringPiece(output.str()).substr(1);
   size_t dot_index = rest.find('.');
@@ -344,7 +344,7 @@ class DepBuilder {
     if (g_flags.gen_all_targets) {
       SymbolSet non_root_targets;
       for (const auto& p : rules_) {
-        if (p.first.get(0) == '.')
+        if (IsSpecialTarget(p.first))
           continue;
         for (const Rule* r : p.second.rules) {
           for (Symbol t : r->inputs)
@@ -356,7 +356,7 @@ class DepBuilder {
 
       for (const auto& p : rules_) {
         Symbol t = p.first;
-        if (!non_root_targets.exists(t) && t.get(0) != '.') {
+        if (!non_root_targets.exists(t) && !IsSpecialTarget(t)) {
           targets.push_back(p.first);
         }
       }
@@ -453,7 +453,7 @@ class DepBuilder {
 
   void PopulateExplicitRule(const Rule* rule) {
     for (Symbol output : rule->outputs) {
-      if (!first_rule_.IsValid() && output.get(0) != '.') {
+      if (!first_rule_.IsValid() && !IsSpecialTarget(output)) {
         first_rule_ = output;
       }
       rules_[output].AddRule(output, rule);
@@ -840,4 +840,8 @@ void QuitDepNodePool() {
   for (DepNode* n : *g_dep_node_pool)
     delete n;
   delete g_dep_node_pool;
+}
+
+bool IsSpecialTarget(Symbol output) {
+  return output.get(0) == '.' && output.get(1) != '.';
 }

--- a/dep.h
+++ b/dep.h
@@ -63,4 +63,6 @@ void MakeDep(Evaluator* ev,
              const vector<Symbol>& targets,
              vector<NamedDepNode>* nodes);
 
+bool IsSpecialTarget(Symbol output);
+
 #endif  // DEP_H_

--- a/ninja.cc
+++ b/ninja.cc
@@ -483,7 +483,7 @@ class NinjaGenerator {
 
     string rule_name = "phony";
     bool use_local_pool = false;
-    if (node->output.get(0) == '.') {
+    if (IsSpecialTarget(node->output)) {
       return;
     }
     if (g_flags.enable_debug) {


### PR DESCRIPTION
The checks for special targets and suffix rules looking for outputs
that start with ".", but this matches outputs that start with "../".
Add an IsSpecialTarget function that checks for "." followed by
something that is not another ".".

Bug: 139495363
Test: m DIST_DIR=../dist dist
Change-Id: Id8708cb46b81b65997e8497aa3e6c918e3c5ca4e