### PR TITLE
Add support for --default_pool in ninja mode

### DIFF
--- a/flags.cc
+++ b/flags.cc
@@ -161,6 +161,8 @@ void Flags::Parse(int argc, char** argv) {
     } else if (ParseCommandLineOptionWithArg("--writable", argv, &i,
                                              &writable_str)) {
       writable.push_back(writable_str);
+    } else if (ParseCommandLineOptionWithArg("--default_pool", argv, &i,
+                                             &default_pool)) {
     } else if (arg[0] == '-') {
       ERROR("Unknown flag: %s", arg);
     } else {

--- a/flags.h
+++ b/flags.h
@@ -55,6 +55,7 @@ struct Flags {
   bool warn_phony_looks_real;
   bool werror_phony_looks_real;
   bool werror_writable;
+  const char* default_pool;
   const char* goma_dir;
   const char* ignore_dirty_pattern;
   const char* no_ignore_dirty_pattern;

--- a/ninja.cc
+++ b/ninja.cc
@@ -570,10 +570,18 @@ class NinjaGenerator {
       }
     }
     *o << "\n";
+
+    string pool;
     if (node->ninja_pool_var) {
-      string pool;
       node->ninja_pool_var->Eval(ev_, &pool);
-      *o << " pool = " << pool << "\n";
+    }
+
+    if (pool != "") {
+      if (pool != "none") {
+        *o << " pool = " << pool << "\n";
+      }
+    } else if (g_flags.default_pool) {
+      *o << " pool = " << g_flags.default_pool << "\n";
     } else if (use_local_pool) {
       *o << " pool = local_pool\n";
     }


### PR DESCRIPTION
Allow a pool to be applied to all rules that don't specify a rule
by passing --default_pool to kati, and allow forcing no pool to be
set even when --default_pool is specified by setting rule-local
variable .KATI_NINJA_POOL := none

Test: ./runtest.rb -c -n ninja_pool.sh
Change-Id: If933fc5a3cc4ad8c904e37836aef54fcd00cf3cc