### PR TITLE
Fixes the tests

### DIFF
--- a/run_test.go
+++ b/run_test.go
@@ -38,6 +38,7 @@ func init() {
 	os.Unsetenv("MAKEFLAGS")
 	os.Unsetenv("MAKELEVEL")
 	os.Setenv("NINJA_STATUS", "NINJACMD: ")
+	os.Setenv("LANG", "C")
 
 	flag.BoolVar(&ckati, "ckati", false, "use ckati")
 	flag.BoolVar(&ninja, "ninja", false, "use ninja")


### PR DESCRIPTION
When the language of system is not English and localizations are installed `make` outputs messages in it causing the tests be falsely marked as failed. This PR fixes this.