### PR TITLE
Implement "fake_output" feature in ninja

### DIFF
--- a/flags.cc
+++ b/flags.cc
@@ -106,6 +106,8 @@ void Flags::Parse(int argc, char** argv) {
       no_builtin_rules = true;
     } else if (!strcmp(arg, "--no_ninja_prelude")) {
       no_ninja_prelude = true;
+    } else if (!strcmp(arg, "--use_ninja_phony_output")) {
+      use_ninja_phony_output = true;
     } else if (!strcmp(arg, "--werror_find_emulator")) {
       werror_find_emulator = true;
     } else if (!strcmp(arg, "--werror_overriding_commands")) {

--- a/flags.h
+++ b/flags.h
@@ -43,6 +43,7 @@ struct Flags {
   bool color_warnings;
   bool no_builtin_rules;
   bool no_ninja_prelude;
+  bool use_ninja_phony_output;
   bool werror_find_emulator;
   bool werror_overriding_commands;
   bool warn_implicit_rules;

--- a/ninja.cc
+++ b/ninja.cc
@@ -557,7 +557,7 @@ class NinjaGenerator {
     }
     *o << ": " << rule_name;
     vector<Symbol> order_onlys;
-    if (node->is_phony) {
+    if (node->is_phony && !g_flags.use_ninja_phony_output) {
       *o << " _kati_always_build_";
     }
     for (auto const& d : node->deps) {
@@ -584,6 +584,9 @@ class NinjaGenerator {
       *o << " pool = " << g_flags.default_pool << "\n";
     } else if (use_local_pool) {
       *o << " pool = local_pool\n";
+    }
+    if (node->is_phony && g_flags.use_ninja_phony_output) {
+      *o << " phony_output = true\n";
     }
     if (node->is_default_target) {
       unique_lock<mutex> lock(mu_);
@@ -618,7 +621,9 @@ class NinjaGenerator {
       fprintf(fp_, "pool local_pool\n");
       fprintf(fp_, " depth = %d\n\n", g_flags.num_jobs);
 
-      fprintf(fp_, "build _kati_always_build_: phony\n\n");
+      if (!g_flags.use_ninja_phony_output) {
+        fprintf(fp_, "build _kati_always_build_: phony\n\n");
+      }
     }
 
     unique_ptr<ThreadPool> tp(NewThreadPool(g_flags.num_jobs));


### PR DESCRIPTION
Specific to the Android fork of ninja, see:
https://android-review.googlesource.com/c/platform/external/ninja/+/1200345

This closely matches the .PHONY semantics of Make, and allows more sanity checks to be enabled in ninja (to verify that commands actually create/update their outputs).