### PR TITLE
func: rewrite a loop to appease -Wunreachable-code-loop-increment

### DIFF
--- a/func.cc
+++ b/func.cc
@@ -283,9 +283,10 @@ void WordsFunc(const vector<Value*>& args, Evaluator* ev, string* s) {
 
 void FirstwordFunc(const vector<Value*>& args, Evaluator* ev, string* s) {
   const string&& text = args[0]->Eval(ev);
-  for (StringPiece tok : WordScanner(text)) {
-    AppendString(tok, s);
-    return;
+  WordScanner ws(text);
+  auto begin = ws.begin();
+  if (begin != ws.end()) {
+    AppendString(*begin, s);
   }
 }
 


### PR DESCRIPTION
This warning catches loops that can only execute once. It's unhappy
about the following code:

```
build/kati/func.cc:286:3: error: loop will run at most once (loop
increment never executed) [-Werror,-Wunreachable-code-loop-increment]
  for (StringPiece tok : WordScanner(text)) {
  ^~~
```

Since that behavior seems intended here, just tweak the code to silence
the warning.

b/150166387

Test: TreeHugger passed at
https://android-review.googlesource.com/c/platform/build/kati/+/1252837