### PR TITLE
Display include stack when encountering an error.

### DIFF
--- a/eval.cc
+++ b/eval.cc
@@ -444,6 +444,7 @@ void Evaluator::EvalInclude(const IncludeStmt* stmt) {
       }
     }
 
+    include_stack_.push_back(stmt->loc());
     for (const string& fname : *files) {
       if (!stmt->should_exist && g_flags.ignore_optional_include_pattern &&
           Pattern(g_flags.ignore_optional_include_pattern).Match(fname)) {
@@ -451,6 +452,7 @@ void Evaluator::EvalInclude(const IncludeStmt* stmt) {
       }
       DoInclude(fname);
     }
+    include_stack_.pop_back();
   }
 }
 
@@ -555,6 +557,9 @@ string Evaluator::GetShellAndFlag() {
 }
 
 void Evaluator::Error(const string& msg) {
+  for (auto& inc : include_stack_) {
+    fprintf(stderr, "In file included from %s:%d:\n", LOCF(inc));
+  }
   ERROR_LOC(loc_, "%s", msg.c_str());
 }
 

--- a/eval.h
+++ b/eval.h
@@ -143,6 +143,8 @@ class Evaluator {
   bool is_bootstrap_;
   bool is_commandline_;
 
+  std::vector<Loc> include_stack_;
+
   bool avoid_io_;
   // This value tracks the nest level of make expressions. For
   // example, $(YYY) in $(XXX $(YYY)) is evaluated with depth==2.


### PR DESCRIPTION
I found this change very useful when debugging a problem in the Android build (I was seeing an error coming from one of the many inclusions of `soong_cc_prebuilt.mk` from `out/soong/Android-$TARGET.mk`, and needed to know which inclusion had the problem).