### PR TITLE
Support '..' in find emulation

### DIFF
--- a/find_test.cc
+++ b/find_test.cc
@@ -131,6 +131,7 @@ int FindUnitTests() {
   //  drwxr-x--- top
   //  lrwxrwxrwx top/E -> missing
   //  lrwxrwxrwx top/C -> A
+  //  lrwxrwxrwx top/F -> A/B
   //  -rw-r----- top/a
   //  drwxr-x--- top/A
   //  lrwxrwxrwx top/A/D -> B
@@ -141,6 +142,7 @@ int FindUnitTests() {
   Run("cd top && ln -s A C");
   Run("cd top/A && ln -s B D");
   Run("cd top && ln -s missing E");
+  Run("cd top && ln -s A/B F");
   Run("touch top/a top/A/b top/A/B/z");
 
   InitFindEmulator();
@@ -164,6 +166,17 @@ int FindUnitTests() {
   CompareFind("find top -type f -name 'a*' -o -name \\*b");
   CompareFind("find top \\! -name 'a*'");
   CompareFind("find top \\( -name 'a*' \\)");
+
+  // Basic use of ..
+  CompareFind("cd top/C; find ../A");
+
+  // Use of .. in chdir
+  CompareFind("cd top/A/..; find .");
+
+  // .. through a symlink in chdir, should list under top/A/...
+  CompareFind("cd top/F; find ../");
+  // .. through a symlink in finddir, should do the same
+  CompareFind("cd top; find F/..");
 
   ExpectParseFailure("find top -name a\\*");
 

--- a/strutil.cc
+++ b/strutil.cc
@@ -494,7 +494,7 @@ string SortWordsInString(StringPiece s) {
 
 string ConcatDir(StringPiece b, StringPiece n) {
   string r;
-  if (!b.empty()) {
+  if (!b.empty() && (n.empty() || n[0] != '/')) {
     b.AppendToString(&r);
     r += '/';
   }

--- a/strutil_test.cc
+++ b/strutil_test.cc
@@ -198,6 +198,18 @@ void TestFindEndOfLineInvalidAccess() {
   ASSERT_EQ(FindEndOfLine(CreateProtectedString("a\\"), 0, &lf_cnt), 2);
 }
 
+void TestConcatDir() {
+  ASSERT_EQ(ConcatDir("", ""), "");
+  ASSERT_EQ(ConcatDir(".", ""), "");
+  ASSERT_EQ(ConcatDir("", "."), "");
+  ASSERT_EQ(ConcatDir("a", "b"), "a/b");
+  ASSERT_EQ(ConcatDir("a/", "b"), "a/b");
+  ASSERT_EQ(ConcatDir("a", "/b"), "/b");
+  ASSERT_EQ(ConcatDir("a", ".."), "");
+  ASSERT_EQ(ConcatDir("a", "../b"), "b");
+  ASSERT_EQ(ConcatDir("a", "../../b"), "../b");
+}
+
 }  // namespace
 
 int main() {
@@ -214,5 +226,6 @@ int main() {
   TestFindEndOfLine();
   TestWordScannerInvalidAccess();
   TestFindEndOfLineInvalidAccess();
+  TestConcatDir();
   assert(!g_failed);
 }


### PR DESCRIPTION
This was our biggest source of fallbacks out of the find emulator on AOSP -- the number of executed shell commands dropped from 53 to 29 after this change. There are only two fallbacks left after this, both using globs in their finddirs (which turns out to be a much more
complicated change).

I'm seeing similar ratios on our flame (Pixel 4) builds in our internal trees.

Test: build-aosp_crosshatch.ninja is the same on AOSP master before/after
Test: build-flame.ninja in our internal master is also the same