### PR TITLE
Support '*' in finddirs

### DIFF
--- a/find_test.cc
+++ b/find_test.cc
@@ -109,8 +109,6 @@ void CompareFind(const string& cmd) {
 }
 
 void ExpectParseFailure(const string& cmd) {
-  Run(cmd);
-
   FindCommand fc;
   if (fc.Parse(cmd)) {
     fprintf(stderr, "Expected parse failure for `%s`\n", cmd.c_str());
@@ -155,6 +153,9 @@ int FindUnitTests() {
   CompareFind("find -L top/C");
   CompareFind("find -L top/C/.");
 
+  // A file in finddir
+  CompareFind("find top/A/b");
+
   CompareFind("cd top && find C");
   CompareFind("cd top && find -L C");
   CompareFind("cd top/C && find .");
@@ -178,7 +179,13 @@ int FindUnitTests() {
   // .. through a symlink in finddir, should do the same
   CompareFind("cd top; find F/..");
 
+  // * in a finddir
+  CompareFind("find top/*/B");
+
   ExpectParseFailure("find top -name a\\*");
+
+  // * in a chdir is not supported
+  ExpectParseFailure("cd top/*/B && find .");
 
   return unit_test_failed ? 1 : 0;
 }


### PR DESCRIPTION
(This is on top of https://github.com/google/kati/pull/190 )

To support commands like:

```
  find foo/*/src -name ...
```

Add a FindNodes function that fits in between FindDir (which tries to find a single exact node) and RunFind (which has all of the find/findleaves/print logic).

This covers the last two cases of `find` in AOSP aosp_flame that weren't being handled by the find emulator. In the internal flame build there are 8 (plus 5 more uses of this that are still not handled for other reasons -- grep/sed, etc)

Test: AOSP build-aosp_flame.ninja is the same before/after
Test: internal build-flame.ninja is the same before/after