### PR TITLE
On-demand find emulator initialization

### DIFF
--- a/find.h
+++ b/find.h
@@ -68,6 +68,7 @@ class FindEmulator {
                           string* out) = 0;
 
   static FindEmulator* Get();
+  static unsigned int GetNodeCount();
 
  protected:
   FindEmulator() = default;

--- a/find_test.cc
+++ b/find_test.cc
@@ -77,7 +77,7 @@ void CompareFind(const string& cmd) {
   }
   string emulated;
   if (!FindEmulator::Get()->HandleFind(cmd, fc, Loc(), &emulated)) {
-    fprintf(stderr, "Find emulator cannot parse `%s`\n", cmd.c_str());
+    fprintf(stderr, "Find emulator cannot handle `%s`\n", cmd.c_str());
     exit(1);
   }
 

--- a/stats.cc
+++ b/stats.cc
@@ -20,6 +20,7 @@
 #include <mutex>
 #include <vector>
 
+#include "find.h"
 #include "flags.h"
 #include "log.h"
 #include "stringprintf.h"
@@ -139,4 +140,6 @@ void ReportAllStats() {
     st->DumpTop();
   }
   delete g_stats;
+
+  LOG_STAT("%u find nodes", FindEmulator::GetNodeCount());
 }


### PR DESCRIPTION
(This is based on #190 and #191 which I'll submit first)

Initialing the find emulator was taking longer and longer the more files you had under your source tree (including multiple output directories). In some of my tests on AOSP:

```
  1.81s  (1025k nodes)
  3.29s  (1707k nodes)
  4.97s  (2180k nodes)
  5.83s  (2736k notes)
```

Issue #184 mentions times of >10 minutes, and [this](https://groups.google.com/forum/#!msg/android-building/ruqXTcxicFQ/9i5HV1OvAQAJ) was a report of nearly 22 minutes (3071k notes).

---

With this change, my tests from above take 0.37s and only load 143k nodes, regardless of how many files actually exist.

This change essentially just delays the loading of directories and symlinks until the first time we attempt to access them, instead of loading them all the first time we ever run `find`.

The improvement to our internal builds doesn't look as nice, but they're still less than half the time / nodes loaded compared to before this change.

Fixes #184

Test: AOSP build-aosp_flame.ninja is the same before/after
Test: internal build-flame.ninja is the same before/after