### PR TITLE
Hurd and (k)FreeBSD support

### DIFF
--- a/Makefile.ckati
+++ b/Makefile.ckati
@@ -75,7 +75,7 @@ KATI_CXXFLAGS += -O -DNOLOG
 KATI_CXXFLAGS += -march=native
 #KATI_CXXFLAGS += -pg
 
-ifeq ($(shell uname),Linux)
+ifneq (,$(filter $(shell (uname)),Linux GNU))
 KATI_LIBS := -lrt -lpthread
 endif
 

--- a/strutil.cc
+++ b/strutil.cc
@@ -17,7 +17,6 @@
 #include "strutil.h"
 
 #include <ctype.h>
-#include <limits.h>
 #include <unistd.h>
 
 #include <algorithm>

--- a/strutil.h
+++ b/strutil.h
@@ -17,6 +17,11 @@
 
 #include <string>
 #include <vector>
+#include <limits.h>
+// GNU Hurd doesn't have PATH_MAX
+#if defined(__GNU__) && !defined(PATH_MAX)
+#define PATH_MAX 4096
+#endif
 
 #include "string_piece.h"
 


### PR DESCRIPTION
Hi,

These commits add support for GNU/Hurd and (k)FreeBSD and potentially other BSDs. The code changes are inspired by the relevant part of LLVM, and have been tested in Debian, where the patches have been applied.