### PR TITLE
Support validations in ninja

### DIFF
--- a/dep.h
+++ b/dep.h
@@ -39,6 +39,7 @@ struct DepNode {
   vector<Value*> cmds;
   vector<NamedDepNode> deps;
   vector<NamedDepNode> order_onlys;
+  vector<NamedDepNode> validations;
   bool has_rule;
   bool is_default_target;
   bool is_phony;
@@ -46,6 +47,7 @@ struct DepNode {
   vector<Symbol> implicit_outputs;
   vector<Symbol> actual_inputs;
   vector<Symbol> actual_order_only_inputs;
+  vector<Symbol> actual_validations;
   Vars* rule_vars;
   Var* depfile_var;
   Var* ninja_pool_var;

--- a/flags.cc
+++ b/flags.cc
@@ -108,6 +108,8 @@ void Flags::Parse(int argc, char** argv) {
       no_ninja_prelude = true;
     } else if (!strcmp(arg, "--use_ninja_phony_output")) {
       use_ninja_phony_output = true;
+    } else if (!strcmp(arg, "--use_ninja_validations")) {
+      use_ninja_validations = true;
     } else if (!strcmp(arg, "--werror_find_emulator")) {
       werror_find_emulator = true;
     } else if (!strcmp(arg, "--werror_overriding_commands")) {

--- a/flags.h
+++ b/flags.h
@@ -44,6 +44,7 @@ struct Flags {
   bool no_builtin_rules;
   bool no_ninja_prelude;
   bool use_ninja_phony_output;
+  bool use_ninja_validations;
   bool werror_find_emulator;
   bool werror_overriding_commands;
   bool warn_implicit_rules;

--- a/ninja.cc
+++ b/ninja.cc
@@ -255,6 +255,9 @@ class NinjaGenerator {
     for (auto const& d : node->order_onlys) {
       PopulateNinjaNode(d.second);
     }
+    for (auto const& d : node->validations) {
+      PopulateNinjaNode(d.second);
+    }
   }
 
   StringPiece TranslateCommand(const char* in, string* cmd_buf) {
@@ -569,6 +572,13 @@ class NinjaGenerator {
         *o << " " << EscapeBuildTarget(d.first).c_str();
       }
     }
+    if (!node->validations.empty()) {
+      *o << " |@";
+      for (auto const& d : node->validations) {
+        *o << " " << EscapeBuildTarget(d.first).c_str();
+      }
+    }
+
     *o << "\n";
 
     string pool;

--- a/rule.h
+++ b/rule.h
@@ -51,6 +51,7 @@ class Rule {
   vector<Symbol> inputs;
   vector<Symbol> order_only_inputs;
   vector<Symbol> output_patterns;
+  vector<Symbol> validations;
   bool is_double_colon;
   bool is_suffix_rule;
   vector<Value*> cmds;

--- a/testcase/ninja_validations.sh
+++ b/testcase/ninja_validations.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# TODO(ninja): enable once upstream ninja supports validations
+#
+# Copyright 2015 Google Inc. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+mk="$@"
+
+cat <<EOF >Makefile
+all: a c
+
+a:
+	echo a
+
+b:
+	echo b
+
+a: .KATI_VALIDATIONS := b
+
+c:
+	echo c
+
+d: c
+	echo d
+
+c: .KATI_VALIDATIONS := d
+EOF
+
+all="a b c d"
+if echo "${mk}" | grep kati > /dev/null; then
+  mk="${mk} --use_ninja_validations"
+  all="a c"
+fi
+${mk} -j1 $all
+if [ -e ninja.sh ]; then
+  ./ninja.sh -j1 -w dupbuild=err $all
+fi  
+


### PR DESCRIPTION
ckati --use_ninja_validations will convert:
foo: .KATI_VALIDATIONS := bar
to a ninja validation dependency from foo to bar:
build foo: rule |@ bar

Using .KATI_VALIDATIONS without setting --use_ninja_validations is
an error.

Test: ./runtest.rb -c -n -a ninja_validations.sh
Change-Id: I4db1f32d8c5fe96268c0d16b78a040a9b9cc2759