### PR TITLE
Merge changes from AOSP

### DIFF
--- a/Makefile.ckati
+++ b/Makefile.ckati
@@ -102,10 +102,10 @@ $(KATI_CXX_TEST_EXES): $(KATI_BIN_PATH)/%: $(KATI_INTERMEDIATES_PATH)/%.o
 	$(KATI_LD) $^ -o $@ $(KATI_LIBS)
 
 # Rule to generate version.cc
-KATI_GIT_DIR := $(shell git -C $(KATI_SRC_PATH) rev-parse --show-toplevel)
+KATI_GIT_DIR := $(shell cd $(KATI_SRC_PATH); realpath `git rev-parse --git-dir`)
 KATI_VERSION_DEPS :=
 ifneq ($(KATI_GIT_DIR),)
-KATI_VERSION_DEPS := $(wildcard $(KATI_GIT_DIR)/.git/HEAD $(KATI_GIT_DIR)/.git/index)
+KATI_VERSION_DEPS := $(wildcard $(KATI_GIT_DIR)/HEAD $(KATI_GIT_DIR)/index)
 endif
 ifneq ($(KATI_VERSION_DEPS),)
 KATI_VERSION := $(shell git -C $(KATI_GIT_DIR) rev-parse HEAD)

--- a/src/Android.bp
+++ b/src/Android.bp
@@ -68,6 +68,11 @@ cc_binary_host {
     defaults: ["ckati_defaults"],
     srcs: ["main.cc"],
     whole_static_libs: ["libckati"],
+    target: {
+        linux_glibc: {
+            shared_libs: ["libjemalloc"],
+        },
+    },
 }
 
 cc_binary_host {


### PR DESCRIPTION
Apparently we had pushed a few changes just to AOSP:

* Link ckati against jemalloc if host machine runs Linux.
* Support git submodules in version.cc generation.

The git one was causing conflicts for my latest merge to AOSP (after #200 included a change to support git worktrees)