### PR TITLE
Add the `--dump_include_json` command line option.

### DIFF
--- a/src/flags.cc
+++ b/src/flags.cc
@@ -146,6 +146,7 @@ void Flags::Parse(int argc, char** argv) {
     } else if (!strcmp(arg, "--werror_real_no_cmds")) {
       warn_real_no_cmds = true;
       werror_real_no_cmds = true;
+    } else if (ParseCommandLineOptionWithArg("--dump_include_json", argv, &i, &dump_include_json)) {
     } else if (ParseCommandLineOptionWithArg("-j", argv, &i, &num_jobs_str)) {
       num_jobs = strtol(num_jobs_str, NULL, 10);
       if (num_jobs <= 0) {

--- a/src/flags.h
+++ b/src/flags.h
@@ -27,6 +27,7 @@ struct Flags {
   bool detect_android_echo;
   bool detect_depfiles;
   bool dump_kati_stamp;
+  const char *dump_include_json;
   bool enable_debug;
   bool enable_kati_warnings;
   bool enable_stat_logs;

--- a/src/main.cc
+++ b/src/main.cc
@@ -257,14 +257,14 @@ static int Run(const vector<Symbol>& targets,
   }
   ev->set_is_bootstrap(false);
 
-  ev->set_is_commandline(true);
+  ev->in_command_line();
   for (StringPiece l : cl_vars) {
     vector<Stmt*> asts;
     Parse(Intern(l).str(), Loc("*bootstrap*", 0), &asts);
     CHECK(asts.size() == 1);
     asts[0]->Eval(ev.get());
   }
-  ev->set_is_commandline(false);
+  ev->in_toplevel_makefile(std::string(g_flags.makefile));
 
   {
     ScopedTimeReporter tr("eval time");
@@ -278,6 +278,10 @@ static int Run(const vector<Symbol>& targets,
   for (ParseErrorStmt* err : GetParseErrors()) {
     WARN_LOC(err->loc(), "warning for parse error in an unevaluated line: %s",
              err->msg.c_str());
+  }
+
+  if (g_flags.dump_include_json != nullptr) {
+    ev->DumpIncludeJSON(std::string(g_flags.dump_include_json));
   }
 
   vector<NamedDepNode> nodes;


### PR DESCRIPTION
It allows one to dump the Makefile inclusion graph.

Some example jq commands:

List of Makefiles including a specific one:

```
jq '.nodes[] | select((.includes | index("$MAKEFILE") != null)) | .file'
```

List of Makefiles included by a Makefile:

```
jq '.nodes[] | select(.file == "$MAKEFILE")'
```

List of all seen Makefiles:

```
jq '.nodes[].file'

```