### PR TITLE
Add .KATI_SYMLINK_OUTPUTS to support declared symlink_outputs in Ninja

### DIFF
--- a/src/dep.cc
+++ b/src/dep.cc
@@ -142,6 +142,7 @@ bool IsSuffixRule(Symbol output) {
 struct RuleMerger {
   vector<const Rule*> rules;
   vector<pair<Symbol, RuleMerger*>> implicit_outputs;
+  vector<Symbol> symlink_outputs;
   vector<Symbol> validations;
   const Rule* primary_rule;
   const RuleMerger* parent;
@@ -154,6 +155,8 @@ struct RuleMerger {
   void AddImplicitOutput(Symbol output, RuleMerger* merger) {
     implicit_outputs.push_back(make_pair(output, merger));
   }
+
+  void AddSymlinkOutput(Symbol output) { symlink_outputs.push_back(output); }
 
   void AddValidation(Symbol validation) { validations.push_back(validation); }
 
@@ -249,11 +252,23 @@ struct RuleMerger {
         n->loc = r->loc;
     }
 
+    SymbolSet all_outputs = SymbolSet();
+    all_outputs.insert(output);
+
     for (auto& implicit_output : implicit_outputs) {
       n->implicit_outputs.push_back(implicit_output.first);
+      all_outputs.insert(implicit_output.first);
       for (const Rule* r : implicit_output.second->rules) {
         FillDepNodeFromRule(output, r, n);
       }
+    }
+
+    for (auto& symlink_output : symlink_outputs) {
+      if (!all_outputs.exists(symlink_output)) {
+        ERROR_LOC(primary_rule->cmd_loc(), "*** undeclared symlink output: %s",
+                  symlink_output.c_str());
+      }
+      n->symlink_outputs.push_back(symlink_output);
     }
 
     for (auto& validation : validations) {
@@ -286,6 +301,7 @@ class DepBuilder {
         implicit_rules_(new RuleTrie()),
         depfile_var_name_(Intern(".KATI_DEPFILE")),
         implicit_outputs_var_name_(Intern(".KATI_IMPLICIT_OUTPUTS")),
+        symlink_outputs_var_name_(Intern(".KATI_SYMLINK_OUTPUTS")),
         ninja_pool_var_name_(Intern(".KATI_NINJA_POOL")),
         validations_var_name_(Intern(".KATI_VALIDATIONS")) {
     ScopedTimeReporter tr("make dep (populate)");
@@ -439,6 +455,17 @@ class DepBuilder {
         for (StringPiece validation : WordScanner(validations)) {
           Symbol sym = Intern(TrimLeadingCurdir(validation));
           p.second.AddValidation(sym);
+        }
+      }
+
+      var = vars->Lookup(symlink_outputs_var_name_);
+      if (var->IsDefined()) {
+        string symlink_outputs;
+        var->Eval(ev_, &symlink_outputs);
+
+        for (StringPiece output : WordScanner(symlink_outputs)) {
+          Symbol sym = Intern(TrimLeadingCurdir(output));
+          p.second.AddSymlinkOutput(sym);
         }
       }
     }
@@ -822,6 +849,12 @@ class DepBuilder {
       n->validations.push_back({validation, c});
     }
 
+    if (!g_flags.use_ninja_symlink_outputs && !n->symlink_outputs.empty()) {
+      ERROR_LOC(n->loc,
+                ".KATI_SYMLINK_OUTPUTS not allowed without "
+                "--use_ninja_symlink_outputs");
+    }
+
     // Block on werror_writable/werror_phony_looks_real, because otherwise we
     // can't rely on is_phony being valid for this check.
     if (!n->is_phony && n->cmds.empty() && g_flags.werror_writable &&
@@ -898,6 +931,7 @@ class DepBuilder {
   SymbolSet restat_;
   Symbol depfile_var_name_;
   Symbol implicit_outputs_var_name_;
+  Symbol symlink_outputs_var_name_;
   Symbol ninja_pool_var_name_;
   Symbol validations_var_name_;
 };

--- a/src/dep.h
+++ b/src/dep.h
@@ -46,6 +46,7 @@ struct DepNode {
   bool is_phony;
   bool is_restat;
   vector<Symbol> implicit_outputs;
+  vector<Symbol> symlink_outputs;
   vector<Symbol> actual_inputs;
   vector<Symbol> actual_order_only_inputs;
   vector<Symbol> actual_validations;

--- a/src/flags.cc
+++ b/src/flags.cc
@@ -108,6 +108,8 @@ void Flags::Parse(int argc, char** argv) {
       no_ninja_prelude = true;
     } else if (!strcmp(arg, "--use_ninja_phony_output")) {
       use_ninja_phony_output = true;
+    } else if (!strcmp(arg, "--use_ninja_symlink_outputs")) {
+      use_ninja_symlink_outputs = true;
     } else if (!strcmp(arg, "--use_ninja_validations")) {
       use_ninja_validations = true;
     } else if (!strcmp(arg, "--werror_find_emulator")) {

--- a/src/flags.h
+++ b/src/flags.h
@@ -46,6 +46,7 @@ struct Flags {
   bool no_builtin_rules;
   bool no_ninja_prelude;
   bool use_ninja_phony_output;
+  bool use_ninja_symlink_outputs;
   bool use_ninja_validations;
   bool werror_find_emulator;
   bool werror_overriding_commands;

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -583,6 +583,14 @@ class NinjaGenerator {
 
     *o << "\n";
 
+    if (!node->symlink_outputs.empty()) {
+      *o << " symlink_outputs =";
+      for (auto const& s : node->symlink_outputs) {
+        *o << " " << EscapeBuildTarget(s);
+      }
+      *o << "\n";
+    }
+
     string pool;
     if (node->ninja_pool_var) {
       node->ninja_pool_var->Eval(ev_, &pool);

--- a/testcase/ninja_symlink_outputs.sh
+++ b/testcase/ninja_symlink_outputs.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+#
+# Copyright 2020 Google Inc. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+mk="$@"
+
+cat <<EOF >Makefile
+dangling_symlink:
+	ln -sf nil dangling_symlink
+dangling_symlink: .KATI_SYMLINK_OUTPUTS := dangling_symlink
+
+file:
+	touch file
+
+resolved_symlink: file
+	ln -sf file resolved_symlink
+resolved_symlink: .KATI_SYMLINK_OUTPUTS := resolved_symlink
+
+incorrectly_declared_symlink:
+	ln -sf nil incorrectly_declared_symlink
+incorrectly_declared_symlink: .KATI_SYMLINK_OUTPUTS := something_else
+
+foo bar: file
+	ln -sf file foo && cp foo bar
+foo: .KATI_SYMLINK_OUTPUTS := foo
+bar: .KATI_SYMLINK_OUTPUTS := bar
+EOF
+
+all="dangling_symlink resolved_symlink foo bar"
+if echo "${mk}" | grep kati > /dev/null; then
+  mk="${mk} --use_ninja_symlink_outputs"
+fi
+${mk} -j1 $all
+
+if [ -e ninja.sh ]; then
+  ./ninja.sh -j1 $all
+
+  if ! grep -A1 "build dangling_symlink:" build.ninja | grep -q "symlink_outputs = dangling_symlink"; then
+    echo "symlink_outputs not present for dangling_symlink in build.ninja"
+  fi
+  if ! grep -A1 "build resolved_symlink:" build.ninja | grep -q "symlink_outputs = resolved_symlink"; then
+    echo "symlink_outputs not present for resolved_symlink in build.ninja"
+  fi
+  if grep -A1 "build file:" build.ninja | grep -q "symlink_outputs ="; then
+    echo "unexpected symlink_outputs present for file in build.ninja"
+  fi
+
+  # Even though this was a multi-output Make rule, Kati generates individual build
+  # statements for each of the outputs, therefore the symlink_outputs list is a singleton.
+  if ! grep -A1 "build foo: rule" build.ninja | grep -q "symlink_outputs = foo"; then
+    echo "symlink_outputs not present for foo in build.ninja"
+  fi
+  if ! grep -A1 "build bar: rule" build.ninja | grep -q "symlink_outputs = bar"; then
+    echo "symlink_outputs not present for bar in build.ninja"
+  fi
+
+  ${mk} -j1 "incorrectly_declared_symlink" 2> kati.err
+  # The actual error message contains the line number in the Makefile.
+  if ! grep "Makefile:" kati.err | grep "undeclared symlink output: something_else"; then
+    echo "did not get undeclared symlink out error message"
+  fi
+fi


### PR DESCRIPTION
`.KATI_SYMLINK_OUTPUTS` accepts a space separated list of paths, and passes the strings into the symlink_outputs Ninja variable.

This feature is gated behind `--use_ninja_symlink_outputs`.