### PR TITLE
Add a Dockerfile to run Kati tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+out/
+
+# As much as .git should not be a dependency of the build, Makefile.ckati reads
+# from git to generate a version.cc file.
+# .git 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,4 @@
 FROM ubuntu:18.04
-# ARG userid
-# ARG groupid
-# ARG username
 
 RUN apt-get update && apt-get install -y make git-core build-essential curl ninja-build python
 
@@ -10,30 +7,12 @@ RUN \
   mkdir -p /goroot && \
   curl https://storage.googleapis.com/golang/go1.14.9.linux-amd64.tar.gz | tar xvzf - -C /goroot --strip-components=1
 
-# Set environment variables.
+# Set environment variables for Go.
 ENV GOROOT /goroot
 ENV GOPATH /gopath
 ENV PATH $GOROOT/bin:$GOPATH/bin:$PATH
 
+# Copy project code.
 COPY . /
- # RUN apt-get update && apt-get install -y git-core gnupg flex bison gperf build-essential zip curl zlib1g-dev gcc-multilib g++-multilib libc6-dev-i386 lib32ncurses5-dev x11proto-core-dev libx11-dev lib32z-dev ccache libgl1-mesa-dev libxml2-utils xsltproc unzip python openjdk-7-jdk
- 
-# RUN curl -o jdk8.tgz https://android.googlesource.com/platform/prebuilts/jdk/jdk8/+archive/master.tar.gz \
-#  && tar -zxf jdk8.tgz linux-x86 \
-#  && mv linux-x86 /usr/lib/jvm/java-8-openjdk-amd64 \
-#  && rm -rf jdk8.tgz
-# 
-# RUN curl -o /usr/local/bin/repo https://storage.googleapis.com/git-repo-downloads/repo \
-#  && echo "d06f33115aea44e583c8669375b35aad397176a411de3461897444d247b6c220  /usr/local/bin/repo" | sha256sum --strict -c - \
-#  && chmod a+x /usr/local/bin/repo
-
-# RUN groupadd -g $groupid $username \
-#  && useradd -m -u $userid -g $groupid $username \
-#  && echo $username >/root/username \
-#  && echo "export USER="$username >>/home/$username/.gitconfig
-# COPY gitconfig /home/$username/.gitconfig
-# RUN chown $userid:$groupid /home/$username/.gitconfig
-# ENV HOME=/home/$username
-# ENV USER=$username
 
 ENTRYPOINT make test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+FROM ubuntu:18.04
+# ARG userid
+# ARG groupid
+# ARG username
+
+RUN apt-get update && apt-get install -y make git-core build-essential curl ninja-build python
+
+# Install Go
+RUN \
+  mkdir -p /goroot && \
+  curl https://storage.googleapis.com/golang/go1.14.9.linux-amd64.tar.gz | tar xvzf - -C /goroot --strip-components=1
+
+# Set environment variables.
+ENV GOROOT /goroot
+ENV GOPATH /gopath
+ENV PATH $GOROOT/bin:$GOPATH/bin:$PATH
+
+COPY . /
+ # RUN apt-get update && apt-get install -y git-core gnupg flex bison gperf build-essential zip curl zlib1g-dev gcc-multilib g++-multilib libc6-dev-i386 lib32ncurses5-dev x11proto-core-dev libx11-dev lib32z-dev ccache libgl1-mesa-dev libxml2-utils xsltproc unzip python openjdk-7-jdk
+ 
+# RUN curl -o jdk8.tgz https://android.googlesource.com/platform/prebuilts/jdk/jdk8/+archive/master.tar.gz \
+#  && tar -zxf jdk8.tgz linux-x86 \
+#  && mv linux-x86 /usr/lib/jvm/java-8-openjdk-amd64 \
+#  && rm -rf jdk8.tgz
+# 
+# RUN curl -o /usr/local/bin/repo https://storage.googleapis.com/git-repo-downloads/repo \
+#  && echo "d06f33115aea44e583c8669375b35aad397176a411de3461897444d247b6c220  /usr/local/bin/repo" | sha256sum --strict -c - \
+#  && chmod a+x /usr/local/bin/repo
+
+# RUN groupadd -g $groupid $username \
+#  && useradd -m -u $userid -g $groupid $username \
+#  && echo $username >/root/username \
+#  && echo "export USER="$username >>/home/$username/.gitconfig
+# COPY gitconfig /home/$username/.gitconfig
+# RUN chown $userid:$groupid /home/$username/.gitconfig
+# ENV HOME=/home/$username
+# ENV USER=$username
+
+ENTRYPOINT make test

--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ $ go test --ckati --ninja --all
 
 The above commands run all cKati and Ninja tests in the `testcases/` directory.
 
+Alternatively, you can also run the tests in a Docker container in a prepared
+test enviroment:
+
+```
+$ docker build -t kati-test . && docker run kati-test
+```
+
 How to use for Android
 ----------------------
 


### PR DESCRIPTION
Add a docker container to run Kati tests.

The command is:

```
docker build -t kati-test . && docker run kati-test
```

With this, I don't see test flakes due to Make version mismatches.