### PR TITLE
Revert "Refactor code to detect self-referential variables"

### DIFF
--- a/src/eval.cc
+++ b/src/eval.cc
@@ -709,19 +709,19 @@ void Evaluator::TraceVariableLookup(const char* operation,
   fprintf(assignment_tracefile_, "    }");
 }
 
-void Evaluator::AddVarToEvalStack(const Var* var) {
-  if (vars_for_eval_.find(var) != vars_for_eval_.end()) {
-    self_referential_.insert(var);
+Var* Evaluator::LookupVarForEval(Symbol name) {
+  Var* var = LookupVar(name);
+  if (var != nullptr) {
+    if (symbols_for_eval_.find(name) != symbols_for_eval_.end()) {
+      var->SetSelfReferential();
+    }
+    symbols_for_eval_.insert(name);
   }
-  vars_for_eval_.insert(var);
+  return var;
 }
 
-void Evaluator::RemoveVarFromEvalStack(const Var* var) {
-  vars_for_eval_.erase(var);
-}
-
-bool Evaluator::SelfReferential(const Var* var) {
-  return self_referential_.find(var) != self_referential_.end();
+void Evaluator::VarEvalComplete(Symbol name) {
+  symbols_for_eval_.erase(name);
 }
 
 Var* Evaluator::LookupVar(Symbol name) {

--- a/src/eval.h
+++ b/src/eval.h
@@ -133,12 +133,11 @@ class Evaluator {
   void EvalInclude(const IncludeStmt* stmt);
   void EvalExport(const ExportStmt* stmt);
 
-  void AddVarToEvalStack(const Var* var);
-  void RemoveVarFromEvalStack(const Var* var);
-  bool SelfReferential(const Var* var);
+  Var* LookupVarForEval(Symbol name);
   Var* LookupVar(Symbol name);
   // For target specific variables.
   Var* LookupVarInCurrentScope(Symbol name);
+  void VarEvalComplete(Symbol name);
 
   // Equivalent to LookupVar, but doesn't mark as used.
   Var* PeekVar(Symbol name);
@@ -236,8 +235,7 @@ class Evaluator {
   unordered_map<Symbol, Vars*> rule_vars_;
   vector<const Rule*> rules_;
   unordered_map<Symbol, bool> exports_;
-  std::set<const Var*> vars_for_eval_;
-  std::set<const Var*> self_referential_;
+  std::set<Symbol> symbols_for_eval_;
 
   Rule* last_rule_;
   Vars* current_scope_;

--- a/src/expr.cc
+++ b/src/expr.cc
@@ -124,9 +124,10 @@ class SymRef : public Value {
 
   virtual void Eval(Evaluator* ev, string* s) const override {
     ev->CheckStack();
-    Var* v = ev->LookupVar(name_);
+    Var* v = ev->LookupVarForEval(name_);
     v->Used(ev, name_);
     v->Eval(ev, s);
+    ev->VarEvalComplete(name_);
   }
 
   virtual string DebugString_() const override {
@@ -148,9 +149,10 @@ class VarRef : public Value {
     const string&& name = name_->Eval(ev);
     ev->DecrementEvalDepth();
     Symbol sym = Intern(name);
-    Var* v = ev->LookupVar(sym);
+    Var* v = ev->LookupVarForEval(sym);
     v->Used(ev, sym);
     v->Eval(ev, s);
+    ev->VarEvalComplete(sym);
   }
 
   virtual string DebugString_() const override {

--- a/src/var.cc
+++ b/src/var.cc
@@ -53,7 +53,8 @@ Var::Var(VarOrigin origin, Frame* definition, Loc loc)
       origin_(origin),
       readonly_(false),
       deprecated_(false),
-      obsolete_(false) {}
+      obsolete_(false),
+      self_referential_(false) {}
 
 Var::~Var() {
   diagnostic_messages_.erase(this);
@@ -150,9 +151,7 @@ RecursiveVar::RecursiveVar(Value* v,
 
 void RecursiveVar::Eval(Evaluator* ev, string* s) const {
   ev->CheckStack();
-  ev->AddVarToEvalStack(this);
   v_->Eval(ev, s);
-  ev->RemoveVarFromEvalStack(this);
 }
 
 void RecursiveVar::AppendVar(Evaluator* ev, Value* v) {
@@ -162,7 +161,7 @@ void RecursiveVar::AppendVar(Evaluator* ev, Value* v) {
 }
 
 void RecursiveVar::Used(Evaluator* ev, const Symbol& sym) const {
-  if (ev->SelfReferential(this)) {
+  if (SelfReferential()) {
     ERROR_LOC(
         Location(),
         StringPrintf(

--- a/src/var.h
+++ b/src/var.h
@@ -72,6 +72,9 @@ class Var : public Evaluable {
   bool Obsolete() const { return obsolete_; }
   void SetObsolete(const StringPiece& msg);
 
+  bool SelfReferential() const { return self_referential_; }
+  void SetSelfReferential() { self_referential_ = true; }
+
   const string& DeprecatedMessage() const;
 
   // This variable was used (either written or read from)
@@ -95,6 +98,7 @@ class Var : public Evaluable {
   bool readonly_ : 1;
   bool deprecated_ : 1;
   bool obsolete_ : 1;
+  bool self_referential_ : 1;
 
   const char* diagnostic_message_text() const;
 

--- a/testcase/recursive_self_reference_call.mk
+++ b/testcase/recursive_self_reference_call.mk
@@ -1,0 +1,8 @@
+define element_mask
+ $(if $(1),
+   $(if $(filter $(firstword $(1)),$(2)), T, F)
+   $(call element_mask,$(wordlist 2,$(words $(1)),$(1)),$(2)))
+endef
+
+$(call element_mask,A B C,C)
+


### PR DESCRIPTION
This reverts commit 1ad519cd7aae00be10564469366b50ab9611e8af.

The recursive self-reference check was too broad, catching cases that are valid.
Adds a test that would have caught this issue.