### PR TITLE
Add .KATI_ALLOW_RULES

### DIFF
--- a/src/eval.h
+++ b/src/eval.h
@@ -36,6 +36,12 @@ class Vars;
 
 class IncludeGraph;
 
+enum RulesAllowed {
+  RULES_ALLOWED = 0,
+  RULES_WARNING = 1,
+  RULES_ERROR = 2
+};
+
 enum FrameType {
   ROOT,        // Root node. Exactly one of this exists.
   PHASE,       // Markers for various phases of the execution.
@@ -151,6 +157,7 @@ class Evaluator {
   const unordered_map<Symbol, Vars*>& rule_vars() const { return rule_vars_; }
   const unordered_map<Symbol, bool>& exports() const { return exports_; }
 
+  void PrintIncludeStack();
   void Error(const string& msg);
 
   void in_bootstrap();
@@ -184,6 +191,9 @@ class Evaluator {
   string GetShell();
   string GetShellFlag();
   string GetShellAndFlag();
+
+  // Parse the current value of .KATI_ALLOW_RULES
+  RulesAllowed GetAllowRules();
 
   void CheckStack() {
     void* addr = __builtin_frame_address(0);

--- a/src/symtab.cc
+++ b/src/symtab.cc
@@ -40,6 +40,7 @@ static vector<SymbolData> g_symbol_data;
 
 Symbol kEmptySym;
 Symbol kShellSym;
+Symbol kAllowRulesSym;
 Symbol kKatiReadonlySym;
 Symbol kVariablesSym;
 Symbol kKatiSymbolsSym;
@@ -128,6 +129,7 @@ class Symtab {
 
     kEmptySym = Intern("");
     kShellSym = Intern("SHELL");
+    kAllowRulesSym = Intern(".KATI_ALLOW_RULES");
     kKatiReadonlySym = Intern(".KATI_READONLY");
     kVariablesSym = Intern(".VARIABLES");
     kVariablesSym.SetGlobalVar(new VariableNamesVar(".VARIABLES", true), false,

--- a/src/symtab.h
+++ b/src/symtab.h
@@ -218,6 +218,7 @@ struct hash<Symbol> {
 
 extern Symbol kEmptySym;
 extern Symbol kShellSym;
+extern Symbol kAllowRulesSym;
 extern Symbol kKatiReadonlySym;
 
 void InitSymtab();

--- a/testcase/allow_rules.sh
+++ b/testcase/allow_rules.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+#
+# Copyright 2018 Google Inc. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -u
+
+mk="$@"
+
+cat <<EOF > Makefile
+FOO = A \$(BAR) C
+BAR = B
+
+# Should not issue warnings or errors
+a:
+	echo $@
+
+# Should issue a warning
+.KATI_ALLOW_RULES := warning
+b:
+	echo $@
+
+\$(FOO) :
+	echo $@
+
+# Should not issue warnings or errors
+.KATI_ALLOW_RULES := asdfasdfa
+d:
+	echo $@
+
+# Should not issue warnings or errors
+.KATI_ALLOW_RULES := 
+e:
+	echo $@
+
+# Should issue an error
+.KATI_ALLOW_RULES := error
+c:
+	echo $@
+EOF
+
+if echo "${mk}" | grep -qv "kati"; then
+  # Make doesn't support these warnings, so write the expected output.
+  echo 'Makefile:10: warning: Rule not allowed here for target: b'
+  echo 'Makefile:13: warning: Rule not allowed here for target: A B C'
+  echo 'Makefile:28: *** Rule not allowed here for target: c'
+else
+  ${mk} --no_builtin_rules --warn 2>&1
+fi
+


### PR DESCRIPTION
If .KATI_ALLOW_RULES is set to "error" then defining a rule is an
error.  If .KATI_ALLOW_RULES is set to "warning" then defining a
rule is a warning.  If it is set to anything else (including "")
then rules can be defined as normal.

Example usage:

.KATI_ALLOW_RULES := error
.KATI_ALLOW_RULES :=