### PR TITLE
Add support for -C <directory>

### DIFF
--- a/run_test.go
+++ b/run_test.go
@@ -55,7 +55,7 @@ var normalizeQuotes = normalization{
 
 var normalizeMakeLog = []normalization{
 	normalizeQuotes,
-	{regexp.MustCompile(`make(?:\[\d+\])?: (Entering|Leaving) directory[^\n]*`), ""},
+	{regexp.MustCompile(`make(?:\[\d+\])?: (Entering|Leaving) directory[^\n]*\n`), ""},
 	{regexp.MustCompile(`make(?:\[\d+\])?: `), ""},
 
 	// Normalizations for old/new GNU make.

--- a/src/flags.cc
+++ b/src/flags.cc
@@ -148,6 +148,7 @@ void Flags::Parse(int argc, char** argv) {
     } else if (!strcmp(arg, "--werror_real_no_cmds")) {
       warn_real_no_cmds = true;
       werror_real_no_cmds = true;
+    } else if (ParseCommandLineOptionWithArg("-C", argv, &i, &working_dir)) {
     } else if (ParseCommandLineOptionWithArg("--dump_include_graph", argv, &i,
                                              &dump_include_graph)) {
     } else if (ParseCommandLineOptionWithArg("--dump_variable_assignment_trace",

--- a/src/flags.h
+++ b/src/flags.h
@@ -72,6 +72,7 @@ struct Flags {
   const char* makefile;
   const char* ninja_dir;
   const char* ninja_suffix;
+  const char* working_dir;  // -C <dir>
   int num_cpus;
   int num_jobs;
   int remote_num_jobs;

--- a/src/main.cc
+++ b/src/main.cc
@@ -384,6 +384,11 @@ int main(int argc, char* argv[]) {
     orig_args += argv[i];
   }
   g_flags.Parse(argc, argv);
+  if (g_flags.working_dir) {
+    int ret = chdir(g_flags.working_dir);
+    if (ret != 0)
+      ERROR("*** %s: %s", g_flags.working_dir, strerror(errno));
+  }
   FindFirstMakefie();
   if (g_flags.makefile == NULL)
     ERROR("*** No targets specified and no makefile found.");

--- a/testcase/working_dir.sh
+++ b/testcase/working_dir.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+#
+# Copyright 2021 Google Inc. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+mk="$@"
+
+mkdir -p subdir
+cat <<EOF > subdir/Makefile
+all:
+	@echo 123
+EOF
+
+${mk} -C subdir


### PR DESCRIPTION
Passing -C <dir>, makes ckati change its current working directory to
the directory provided or bail out if that fails. This functionality is
implemented in GNU Make and the option added for compatibility.

Fixes: #180
Signed-off-by: Matthias Maennich <maennich@google.com>