### PR TITLE
ckati: Fix some test cases to accommodate new GNUMake 4 behaviour

### DIFF
--- a/.github/workflows/cpp-ci.yml
+++ b/.github/workflows/cpp-ci.yml
@@ -23,7 +23,7 @@ jobs:
         wget https://github.com/ninja-build/ninja/releases/download/v1.9.0/ninja-linux.zip
         unzip ninja-linux.zip
         rm ninja-linux.zip
-        echo "::add-path::${GITHUB_WORKSPACE}/ninja-bin"
+        echo "${GITHUB_WORKSPACE}/ninja-bin" >> "$GITHUB_PATH"
     - name: make
       run: make -j4 ckati ckati_tests
     - name: clang format

--- a/run_test.go
+++ b/run_test.go
@@ -72,6 +72,9 @@ var normalizeMakeLog = []normalization{
 	{regexp.MustCompile(`/bin/(ba)?sh: line 0: `), ""},
 	// Normalization for "include foo" with C++ kati
 	{regexp.MustCompile(`(: \S+: No such file or directory)\n\*\*\* No rule to make target "[^"]+".`), "$1"},
+	// GNU make 4.0 prints the file:line as part of the error message, e.g.:
+	//    *** [Makefile:4: target] Error 1
+	{regexp.MustCompile(`\[\S+:\d+: `), "["},
 }
 
 var normalizeMakeNinja = normalization{

--- a/src/eval.cc
+++ b/src/eval.cc
@@ -466,7 +466,7 @@ void Evaluator::EvalRule(const RuleStmt* stmt) {
 
   const string&& before_term = stmt->lhs->Eval(this);
   // See semicolon.mk.
-  if (before_term.find_first_not_of(" \t;") == string::npos) {
+  if (before_term.find_first_not_of(" \t\n;") == string::npos) {
     if (stmt->sep == RuleStmt::SEP_SEMICOLON)
       Error("*** missing rule before commands.");
     return;

--- a/testcase/tools/findleaves.py
+++ b/testcase/tools/findleaves.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Copyright (C) 2009 The Android Open Source Project
 #
@@ -25,7 +25,7 @@ import sys
 
 def perform_find(mindepth, prune, dirlist, filenames):
   result = []
-  pruneleaves = set(map(lambda x: os.path.split(x)[1], prune))
+  pruneleaves = set([os.path.split(x)[1] for x in prune])
   for rootdir in dirlist:
     rootdepth = rootdir.count("/")
     for root, dirs, files in os.walk(rootdir, followlinks=True):
@@ -108,7 +108,7 @@ def main(argv):
   results = list(set(perform_find(mindepth, prune, dirlist, filenames)))
   results.sort()
   for r in results:
-    print r
+    print(r)
 
 if __name__ == "__main__":
   main(sys.argv)


### PR DESCRIPTION
This fixes four test cases and the github action. See the single commits for details:

770371b49393 Revert of code change in 97d8f1deb62d ("[C++] Fail for newlines in expanded rule statement")
24a174a64ea8 tests: ignore the error location that GNUMake emits
b71e718365bc testcases/tools/findleaves.py: migrate to python3
378b5fff85e0 Fix github action to not use 'add-path' anymore

Signed-off-by: Matthias Maennich <maennich@google.com>