### PR TITLE
cleanup: use [[fallthrough]] unconditionally

### DIFF
--- a/src/func.cc
+++ b/src/func.cc
@@ -65,9 +65,7 @@ void StripShellComment(string* cmd) {
             in++;
           break;
         }
-#if defined(__has_cpp_attribute) && __has_cpp_attribute(clang::fallthrough)
-        [[clang::fallthrough]];
-#endif
+        [[fallthrough]];
 
       case '\'':
       case '"':

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -535,9 +535,7 @@ class NinjaGenerator {
         case ':':
         case ' ':
           r += '$';
-#if defined(__has_cpp_attribute) && __has_cpp_attribute(clang::fallthrough)
-          [[clang::fallthrough]];
-#endif
+          [[fallthrough]];
         default:
           r += c;
       }


### PR DESCRIPTION
Since we compile with C++17, we can expect `[[fallthrough]]` to be
implemented. Hence, make use of it unconditionally.

Signed-off-by: Matthias Maennich <maennich@google.com>