### PR TITLE
CommandEvaluator: Correct Makefile location for multi statement blocks

### DIFF
--- a/src/command.cc
+++ b/src/command.cc
@@ -190,6 +190,7 @@ void CommandEvaluator::Eval(DepNode* n, vector<Command*>* commands) {
   ev_->set_current_scope(n->rule_vars);
   current_dep_node_ = n;
   for (Value* v : n->cmds) {
+    ev_->set_loc(v->Location());
     const string&& cmds_buf = v->Eval(ev_);
     StringPiece cmds = cmds_buf;
     bool global_echo = !g_flags.is_silent_mode;


### PR DESCRIPTION
If a rule has multiple statements to execute, the location information
was not updated accordingly for any but the first statement.

E.g. consider a Makefile with this content:

```
   test:
      $(warning abc)
      $(warning cde)
```

make would correctly emit:

```
  Makefile:2 abc
  Makefile:3 cde
```

Ckati would not update the line number correctly for the second warning,
and instead would emit

```
  Makefile:2 abc
  Makefile:2 cde
```

Fix that by updating the evaluator command location from the current
command location.

This fixes `testcase/warning.mk` that was currenlty failing du to this
mismatch between GNU make and ckati.