### PR TITLE
Expression Parser: Retain single '$' signs before terminators

### DIFF
--- a/src/expr.cc
+++ b/src/expr.cc
@@ -551,6 +551,7 @@ Value* ParseExprImpl(Loc* loc,
       }
 
       if (terms && strchr(terms, s[i + 1])) {
+        list.push_back(new Literal(StringPiece("$")));
         *index_out = i + 1;
         return Value::NewExpr(item_loc, &list);
       }

--- a/testcase/simple_subst.mk
+++ b/testcase/simple_subst.mk
@@ -1,0 +1,4 @@
+foo := $(subst a,$,bab)
+
+test:
+	echo $(foo)


### PR DESCRIPTION
Single dollar signs without variable reference are treated as literal
dollar signs by GNU Make if they are before a terminator, such as a line
ending or a comma in a function argument list. Let Kati do the same.

Consider the following Makefile

```
foo := $(subst a,$,bab)
test:
    echo $(foo)
```

`foo` expands to `b$b` by replacing occurrences of `'a'` by the literal
`'$'`. The command effective is then `echo b$b`, printing just `'b'` unless
`$b` evaluates to something.

There was a test failing due to this missing corner case implementation
that is now fixed as well: testcase/subst2.mk
Further I added an explicit test case: testcase/simple_subst.mk to
preserve this corner case.