### PR TITLE
EvalIf: Consider any whitespace in variable names an error

### DIFF
--- a/src/eval.cc
+++ b/src/eval.cc
@@ -16,6 +16,7 @@
 
 #include "eval.h"
 
+#include <ctype.h>
 #include <errno.h>
 #include <pthread.h>
 #include <stdio.h>
@@ -574,8 +575,10 @@ void Evaluator::EvalIf(const IfStmt* stmt) {
       string var_name;
       stmt->lhs->Eval(this, &var_name);
       Symbol lhs = Intern(TrimRightSpace(var_name));
-      if (lhs.str().find_first_of(" \t") != string::npos)
+      if (const auto& s = lhs.str();
+          std::find_if(s.begin(), s.end(), ::isspace) != s.end()) {
         Error("*** invalid syntax in conditional.");
+      }
       Var* v = LookupVarInCurrentScope(lhs);
       v->Used(this, lhs);
       is_true = (v->String().empty() == (stmt->op == CondOp::IFNDEF));


### PR DESCRIPTION
Not only are `' '` and `'\t'` are considered bad in variable names used in
if statements, actually any whitespace including `'\n'` is considered
illegal. Fix that by testing for anything matching `isspace`.

This fixes `testcase/ifdef_ret_in_arg.mk`.