### PR TITLE
Add diagnostic make file targets

### DIFF
--- a/.github/workflows/cpp-ci.yml
+++ b/.github/workflows/cpp-ci.yml
@@ -24,6 +24,8 @@ jobs:
         unzip ninja-linux.zip
         rm ninja-linux.zip
         echo "${GITHUB_WORKSPACE}/ninja-bin" >> "$GITHUB_PATH"
+    - name: make info
+      run: make info
     - name: make
       run: make -j4 ckati ckati_tests
     - name: clang format

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,21 @@ all: ckati ckati_tests
 include Makefile.kati
 include Makefile.ckati
 
+info: ckati
+	@echo GNU MAKE VERSION
+	make --version
+	make -f Makefile version --no-print-directory
+	@echo
+	@echo CKATI VERSION
+	./ckati -f Makefile version
+	@echo
+	@echo SHELL VERSION
+	@echo $(SHELL)
+	$(SHELL) --version | head -n 1
+
+version:
+	@echo $(MAKE_VERSION)
+
 test: all ckati_tests
 	go test --ckati --ninja
 


### PR DESCRIPTION
This helps diagnose issues related to the environment this is developed
in. For now, just gather information about GNU Make and the current
shell.

Signed-off-by: Matthias Maennich <maennich@google.com>