### PR TITLE
Bump GNU Make compatibility version

### DIFF
--- a/.github/workflows/cpp-ci.yml
+++ b/.github/workflows/cpp-ci.yml
@@ -24,6 +24,16 @@ jobs:
         unzip ninja-linux.zip
         rm ninja-linux.zip
         echo "${GITHUB_WORKSPACE}/ninja-bin" >> "$GITHUB_PATH"
+    - name: install GNU Make
+      run: |
+        mkdir -p ${GITHUB_WORKSPACE}/make-bin/tmp; cd ${GITHUB_WORKSPACE}/make-bin/tmp
+        wget http://mirrors.kernel.org/ubuntu/pool/main/m/make-dfsg/make_4.2.1-1.2_amd64.deb
+        ar xv make_4.2.1-1.2_amd64.deb
+        tar xf data.tar.xz
+        mv usr/bin/make ../
+        cd ..
+        rm -rf tmp/
+        echo "${GITHUB_WORKSPACE}/make-bin" >> "$GITHUB_PATH"
     - name: make info
       run: make info
     - name: make

--- a/README.md
+++ b/README.md
@@ -1,16 +1,14 @@
-kati
-====
+# kati
 
 [![Build and Test](https://github.com/google/kati/workflows/Build%20and%20Test/badge.svg)](https://github.com/google/kati/actions)
 
-kati is an experimental GNU make clone.
-The main goal of this tool is to speed-up incremental build of Android.
+kati is an experimental GNU make clone. The main goal of this tool is to
+speed-up incremental build of Android.
 
 Currently, kati does not offer a faster build by itself. It instead converts
 your Makefile to a ninja file.
 
-Development
------------
+## Development
 
 Building:
 
@@ -20,7 +18,7 @@ $ make ckati
 
 The above command produces a `ckati` binary in the project root.
 
-Testing (best ran in a Ubuntu 18.04 environment):
+Testing (best ran in a Ubuntu 20.04 environment):
 
 ```
 $ make test
@@ -38,8 +36,20 @@ test enviroment:
 $ docker build -t kati-test . && docker run kati-test
 ```
 
-How to use for Android
-----------------------
+If you are working on a machine that does not provide `make` in the same version
+as kati is currently compatible with, you might want to download a prebuilt
+version instead. For example to use the prebuilt version of Ubuntu 20.04 LTS:
+
+```
+  $ mkdir tmp/ && cd tmp/
+  $ wget http://mirrors.kernel.org/ubuntu/pool/main/m/make-dfsg/make_4.2.1-1.2_amd64.deb
+  $ ar xv make_4.2.1-1.2_amd64.deb
+  $ tar xf data.tar.xz
+  $ cd ..
+  $ PATH=$(pwd)/tmp/usr/bin/:$PATH make test
+```
+
+## How to use for Android
 
 For Android-N+, ckati and ninja is used automatically. There is a prebuilt
 checked in under prebuilts/build-tools that is used.

--- a/src/main.cc
+++ b/src/main.cc
@@ -76,8 +76,8 @@ static void ReadBootstrapMakefile(const vector<Symbol>& targets,
        "CXX?=g++\n"
 #endif
        "AR?=ar\n"
-       // Pretend to be GNU make 3.81, for compatibility.
-       "MAKE_VERSION?=3.81\n"
+       // Pretend to be GNU make 4.2.1, for compatibility.
+       "MAKE_VERSION?=4.2.1\n"
        "KATI?=ckati\n"
        // Overwrite $SHELL environment variable.
        "SHELL=/bin/sh\n"

--- a/testcase/test_version.mk
+++ b/testcase/test_version.mk
@@ -1,0 +1,1 @@
+$(info $(MAKE_VERSION))


### PR DESCRIPTION
Update the GNU Make compatibility version (`MAKE_VERSION`) to 4.2.1. The
previously used version 3.81 had been released 2006 the latest 3.x
version is 3.82, released in 2010. With today's toolchains it is quite a
bit of work to still get a 3.81 compiled and odds are that Kati users
are on newer systems anyway (Kati is compiled with C++17).

Lastly, as of today we validate ckati against the GNU Make provided in
Ubuntu 20.04 LTS, which is currently 4.2.1. So, the best we can say
about compatibility is declaring `MAKE_VERSION=4.2.1`

In order to safeguard this, add explicit steps to use a 4.2.1 GNU Make
for testing in the github actions and add some documentation to achieve
the same result when testing locally.