### PR TITLE
strutil: replace SkipUntil by invocations to strcspn

### DIFF
--- a/src/strutil.cc
+++ b/src/strutil.cc
@@ -60,7 +60,7 @@ WordScanner::Iterator& WordScanner::Iterator::operator++() {
     return *this;
   }
 
-  static const char delimiters[] = "\x09\x0d  ";
+  static const char delimiters[] = "\x09\x0a\x0b\x0c\x0d ";
   // It's intentional we are not using isSpace here. It seems with
   // lambda the compiler generates better code.
   i = s + SkipUntil(in->data() + s, len - s, delimiters,

--- a/src/strutil.cc
+++ b/src/strutil.cc
@@ -410,7 +410,7 @@ size_t FindThreeOutsideParen(StringPiece s, char c1, char c2, char c3) {
 }
 
 size_t FindEndOfLine(StringPiece s, size_t e, size_t* lf_cnt) {
-  static const char delimiters[] = "\0\0\n\n\\\\";
+  static const char delimiters[] = "\0\n\\";
   while (e < s.size()) {
     e += SkipUntil(s.data() + e, s.size() - e, delimiters,
                    [](char c) { return c == 0 || c == '\n' || c == '\\'; });
@@ -502,7 +502,7 @@ static bool NeedsShellEscape(char c) {
 }
 
 void EscapeShell(string* s) {
-  static const char delimiters[] = "\0\0\"\"$$\\\\``";
+  static const char delimiters[] = "\0\"$\\`";
   size_t prev = 0;
   size_t i = SkipUntil(s->c_str(), s->size(), delimiters, NeedsShellEscape);
   if (i == s->size())


### PR DESCRIPTION
This is a series of commits originating from a reported bug that was recently introduced with a8ca5d35306a ("strutil: replace SSE4 specialization with libc call"). The handling of some control characters changed by mistake. This series addresses this issue and simplifies the implementation. This is split into several commits to show the history of those changes. Yet the diff is smallest if seen across the entire pull request.

   strutil: clarify SkipUntil parameters
   strutil: fix delimiters for skipping whitespaces
   strutil: deduplicate delimiters
   strutil: replace SkipUntil by calls to strcspn
