### PR TITLE
Remove some unnecessary heap allocations and init/quit code from main

### DIFF
--- a/src/dep.h
+++ b/src/dep.h
@@ -57,9 +57,6 @@ struct DepNode {
   Loc loc;
 };
 
-void InitDepNodePool();
-void QuitDepNodePool();
-
 void MakeDep(Evaluator* ev,
              const vector<const Rule*>& rules,
              const unordered_map<Symbol, Vars*>& rule_vars,

--- a/src/expr.cc
+++ b/src/expr.cc
@@ -234,7 +234,7 @@ class VarSubst : public Value {
 
 class Func : public Value {
  public:
-  Func(const Loc& loc, FuncInfo* fi) : Value(loc), fi_(fi) {}
+  Func(const Loc& loc, const FuncInfo* fi) : Value(loc), fi_(fi) {}
 
   ~Func() {
     for (Value* a : args_)
@@ -266,7 +266,7 @@ class Func : public Value {
   bool trim_right_space_1st() const { return fi_->trim_right_space_1st; }
 
  private:
-  FuncInfo* fi_;
+  const FuncInfo* fi_;
   vector<Value*> args_;
 };
 
@@ -444,7 +444,7 @@ Value* ParseDollar(Loc* loc, StringPiece s, size_t* index_out) {
       // ${func ...}
       if (vname->IsLiteral()) {
         Literal* lit = static_cast<Literal*>(vname);
-        if (FuncInfo* fi = GetFuncInfo(lit->val())) {
+        if (const FuncInfo* fi = GetFuncInfo(lit->val())) {
           delete lit;
           Func* func = new Func(start_loc, fi);
           ParseFunc(loc, func, s, i + 1, terms, index_out);

--- a/src/func.cc
+++ b/src/func.cc
@@ -959,82 +959,73 @@ void VariableLocationFunc(const vector<Value*>& args,
   }
 }
 
-FuncInfo g_func_infos[] = {
-    {"patsubst", &PatsubstFunc, 3, 3, false, false},
-    {"strip", &StripFunc, 1, 1, false, false},
-    {"subst", &SubstFunc, 3, 3, false, false},
-    {"findstring", &FindstringFunc, 2, 2, false, false},
-    {"filter", &FilterFunc, 2, 2, false, false},
-    {"filter-out", &FilterOutFunc, 2, 2, false, false},
-    {"sort", &SortFunc, 1, 1, false, false},
-    {"word", &WordFunc, 2, 2, false, false},
-    {"wordlist", &WordlistFunc, 3, 3, false, false},
-    {"words", &WordsFunc, 1, 1, false, false},
-    {"firstword", &FirstwordFunc, 1, 1, false, false},
-    {"lastword", &LastwordFunc, 1, 1, false, false},
+#define ENTRY(name, args...) \
+  {                          \
+    name, { name, args }     \
+  }
 
-    {"join", &JoinFunc, 2, 2, false, false},
-    {"wildcard", &WildcardFunc, 1, 1, false, false},
-    {"dir", &DirFunc, 1, 1, false, false},
-    {"notdir", &NotdirFunc, 1, 1, false, false},
-    {"suffix", &SuffixFunc, 1, 1, false, false},
-    {"basename", &BasenameFunc, 1, 1, false, false},
-    {"addsuffix", &AddsuffixFunc, 2, 2, false, false},
-    {"addprefix", &AddprefixFunc, 2, 2, false, false},
-    {"realpath", &RealpathFunc, 1, 1, false, false},
-    {"abspath", &AbspathFunc, 1, 1, false, false},
+static const std::unordered_map<StringPiece, FuncInfo> g_func_info_map = {
 
-    {"if", &IfFunc, 3, 2, false, true},
-    {"and", &AndFunc, 0, 0, true, false},
-    {"or", &OrFunc, 0, 0, true, false},
+    ENTRY("patsubst", &PatsubstFunc, 3, 3, false, false),
+    ENTRY("strip", &StripFunc, 1, 1, false, false),
+    ENTRY("subst", &SubstFunc, 3, 3, false, false),
+    ENTRY("findstring", &FindstringFunc, 2, 2, false, false),
+    ENTRY("filter", &FilterFunc, 2, 2, false, false),
+    ENTRY("filter-out", &FilterOutFunc, 2, 2, false, false),
+    ENTRY("sort", &SortFunc, 1, 1, false, false),
+    ENTRY("word", &WordFunc, 2, 2, false, false),
+    ENTRY("wordlist", &WordlistFunc, 3, 3, false, false),
+    ENTRY("words", &WordsFunc, 1, 1, false, false),
+    ENTRY("firstword", &FirstwordFunc, 1, 1, false, false),
+    ENTRY("lastword", &LastwordFunc, 1, 1, false, false),
 
-    {"value", &ValueFunc, 1, 1, false, false},
-    {"eval", &EvalFunc, 1, 1, false, false},
-    {"shell", &ShellFunc, 1, 1, false, false},
-    {"call", &CallFunc, 0, 0, false, false},
-    {"foreach", &ForeachFunc, 3, 3, false, false},
+    ENTRY("join", &JoinFunc, 2, 2, false, false),
+    ENTRY("wildcard", &WildcardFunc, 1, 1, false, false),
+    ENTRY("dir", &DirFunc, 1, 1, false, false),
+    ENTRY("notdir", &NotdirFunc, 1, 1, false, false),
+    ENTRY("suffix", &SuffixFunc, 1, 1, false, false),
+    ENTRY("basename", &BasenameFunc, 1, 1, false, false),
+    ENTRY("addsuffix", &AddsuffixFunc, 2, 2, false, false),
+    ENTRY("addprefix", &AddprefixFunc, 2, 2, false, false),
+    ENTRY("realpath", &RealpathFunc, 1, 1, false, false),
+    ENTRY("abspath", &AbspathFunc, 1, 1, false, false),
 
-    {"origin", &OriginFunc, 1, 1, false, false},
-    {"flavor", &FlavorFunc, 1, 1, false, false},
+    ENTRY("if", &IfFunc, 3, 2, false, true),
+    ENTRY("and", &AndFunc, 0, 0, true, false),
+    ENTRY("or", &OrFunc, 0, 0, true, false),
 
-    {"info", &InfoFunc, 1, 1, false, false},
-    {"warning", &WarningFunc, 1, 1, false, false},
-    {"error", &ErrorFunc, 1, 1, false, false},
+    ENTRY("value", &ValueFunc, 1, 1, false, false),
+    ENTRY("eval", &EvalFunc, 1, 1, false, false),
+    ENTRY("shell", &ShellFunc, 1, 1, false, false),
+    ENTRY("call", &CallFunc, 0, 0, false, false),
+    ENTRY("foreach", &ForeachFunc, 3, 3, false, false),
 
-    {"file", &FileFunc, 2, 1, false, false},
+    ENTRY("origin", &OriginFunc, 1, 1, false, false),
+    ENTRY("flavor", &FlavorFunc, 1, 1, false, false),
+
+    ENTRY("info", &InfoFunc, 1, 1, false, false),
+    ENTRY("warning", &WarningFunc, 1, 1, false, false),
+    ENTRY("error", &ErrorFunc, 1, 1, false, false),
+
+    ENTRY("file", &FileFunc, 2, 1, false, false),
 
     /* Kati custom extension functions */
-    {"KATI_deprecated_var", &DeprecatedVarFunc, 2, 1, false, false},
-    {"KATI_obsolete_var", &ObsoleteVarFunc, 2, 1, false, false},
-    {"KATI_deprecate_export", &DeprecateExportFunc, 1, 1, false, false},
-    {"KATI_obsolete_export", &ObsoleteExportFunc, 1, 1, false, false},
+    ENTRY("KATI_deprecated_var", &DeprecatedVarFunc, 2, 1, false, false),
+    ENTRY("KATI_obsolete_var", &ObsoleteVarFunc, 2, 1, false, false),
+    ENTRY("KATI_deprecate_export", &DeprecateExportFunc, 1, 1, false, false),
+    ENTRY("KATI_obsolete_export", &ObsoleteExportFunc, 1, 1, false, false),
 
-    {"KATI_profile_makefile", &ProfileFunc, 0, 0, false, false},
-    {"KATI_variable_location", &VariableLocationFunc, 1, 1, false, false},
+    ENTRY("KATI_profile_makefile", &ProfileFunc, 0, 0, false, false),
+    ENTRY("KATI_variable_location", &VariableLocationFunc, 1, 1, false, false),
 };
-
-unordered_map<StringPiece, FuncInfo*>* g_func_info_map;
 
 }  // namespace
 
-void InitFuncTable() {
-  g_func_info_map = new unordered_map<StringPiece, FuncInfo*>;
-  for (size_t i = 0; i < sizeof(g_func_infos) / sizeof(g_func_infos[0]); i++) {
-    FuncInfo* fi = &g_func_infos[i];
-    bool ok = g_func_info_map->emplace(fi->name, fi).second;
-    CHECK(ok);
-  }
-}
-
-void QuitFuncTable() {
-  delete g_func_info_map;
-}
-
-FuncInfo* GetFuncInfo(StringPiece name) {
-  auto found = g_func_info_map->find(name);
-  if (found == g_func_info_map->end())
-    return NULL;
-  return found->second;
+const FuncInfo* GetFuncInfo(StringPiece name) {
+  auto found = g_func_info_map.find(name);
+  if (found == g_func_info_map.end())
+    return nullptr;
+  return &found->second;
 }
 
 const vector<CommandResult*>& GetShellCommandResults() {

--- a/src/func.h
+++ b/src/func.h
@@ -35,10 +35,7 @@ struct FuncInfo {
   bool trim_right_space_1st;
 };
 
-void InitFuncTable();
-void QuitFuncTable();
-
-FuncInfo* GetFuncInfo(StringPiece name);
+const FuncInfo* GetFuncInfo(StringPiece name);
 
 struct FindCommand;
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -23,7 +23,6 @@
 #include <unistd.h>
 
 #include "affinity.h"
-#include "dep.h"
 #include "eval.h"
 #include "exec.h"
 #include "file.h"
@@ -53,7 +52,6 @@ extern "C" const char* __asan_default_options() {
 static void Init() {
   InitSymtab();
   InitFuncTable();
-  InitDepNodePool();
   InitParser();
 }
 
@@ -61,7 +59,6 @@ static void Quit() {
   ReportAllStats();
 
   QuitParser();
-  QuitDepNodePool();
   QuitFuncTable();
   QuitSymtab();
 }

--- a/src/main.cc
+++ b/src/main.cc
@@ -51,7 +51,6 @@ extern "C" const char* __asan_default_options() {
 
 static void Init() {
   InitSymtab();
-  InitFuncTable();
   InitParser();
 }
 
@@ -59,7 +58,6 @@ static void Quit() {
   ReportAllStats();
 
   QuitParser();
-  QuitFuncTable();
   QuitSymtab();
 }
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -50,7 +50,6 @@ extern "C" const char* __asan_default_options() {
 }
 
 static void Init() {
-  InitSymtab();
   InitParser();
 }
 
@@ -58,7 +57,6 @@ static void Quit() {
   ReportAllStats();
 
   QuitParser();
-  QuitSymtab();
 }
 
 static void ReadBootstrapMakefile(const vector<Symbol>& targets,

--- a/src/main.cc
+++ b/src/main.cc
@@ -49,16 +49,6 @@ extern "C" const char* __asan_default_options() {
   return "detect_leaks=0:allow_user_segv_handler=1";
 }
 
-static void Init() {
-  InitParser();
-}
-
-static void Quit() {
-  ReportAllStats();
-
-  QuitParser();
-}
-
 static void ReadBootstrapMakefile(const vector<Symbol>& targets,
                                   vector<Stmt*>* stmts) {
   string bootstrap =
@@ -367,7 +357,6 @@ int main(int argc, char* argv[]) {
     HandleRealpath(argc - 2, argv + 2);
     return 0;
   }
-  Init();
   string orig_args;
   for (int i = 0; i < argc; i++) {
     if (i)
@@ -387,6 +376,6 @@ int main(int argc, char* argv[]) {
   if (g_flags.use_find_emulator)
     InitFindEmulator();
   int r = Run(g_flags.targets, g_flags.cl_vars, orig_args);
-  Quit();
+  ReportAllStats();
   return r;
 }

--- a/src/parser.h
+++ b/src/parser.h
@@ -37,9 +37,6 @@ void ParseAssignStatement(StringPiece line,
                           StringPiece* rhs,
                           AssignOp* op);
 
-void InitParser();
-void QuitParser();
-
 const vector<ParseErrorStmt*>& GetParseErrors();
 
 #endif  // PARSER_H_

--- a/src/symtab.cc
+++ b/src/symtab.cc
@@ -193,18 +193,10 @@ class Symtab {
 #endif
 };
 
-static Symtab* g_symtab;
-
-void InitSymtab() {
-  g_symtab = new Symtab;
-}
-
-void QuitSymtab() {
-  delete g_symtab;
-}
+static Symtab g_symtab;
 
 Symbol Intern(StringPiece s) {
-  return g_symtab->Intern(s);
+  return g_symtab.Intern(s);
 }
 
 string JoinSymbols(const vector<Symbol>& syms, const char* sep) {
@@ -217,5 +209,5 @@ string JoinSymbols(const vector<Symbol>& syms, const char* sep) {
 }
 
 vector<StringPiece> GetSymbolNames(std::function<bool(Var*)> const& filter) {
-  return g_symtab->GetSymbolNames(filter);
+  return g_symtab.GetSymbolNames(filter);
 }

--- a/src/symtab.h
+++ b/src/symtab.h
@@ -221,8 +221,6 @@ extern Symbol kShellSym;
 extern Symbol kAllowRulesSym;
 extern Symbol kKatiReadonlySym;
 
-void InitSymtab();
-void QuitSymtab();
 Symbol Intern(StringPiece s);
 
 string JoinSymbols(const vector<Symbol>& syms, const char* sep);


### PR DESCRIPTION
Most of the data structures that are initialized during Init() and cleaned up during Quit() are either constant or can be initialized at program start instead. This pull request addresses this for dep, func, symtab and parser to eventually remove the init/quit code from main entirely.