### PR TITLE
Fix crash when using --empty_ninja_file

### DIFF
--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -645,6 +645,20 @@ class NinjaGenerator {
       for (const auto& node : nodes_) {
         EmitNode(node, out);
       }
+
+      std::string default_targets;
+      if (g_flags.targets.empty() || g_flags.gen_all_targets) {
+        CHECK(default_target_);
+        default_targets = EscapeBuildTarget(default_target_->output);
+      } else {
+        for (Symbol s : g_flags.targets) {
+          if (!default_targets.empty())
+            default_targets += ' ';
+          default_targets += EscapeBuildTarget(s);
+        }
+      }
+      out << "\n"
+          << "default " << default_targets << '\n';
     }
 
     SymbolSet used_env_vars(Vars::used_env_vars());
@@ -653,22 +667,6 @@ class NinjaGenerator {
     for (Symbol e : used_env_vars) {
       StringPiece val(getenv(e.c_str()));
       used_envs_.emplace(e.str(), val.as_string());
-    }
-
-    std::string default_targets;
-    if (g_flags.targets.empty() || g_flags.gen_all_targets) {
-      CHECK(default_target_);
-      default_targets = EscapeBuildTarget(default_target_->output);
-    } else {
-      for (Symbol s : g_flags.targets) {
-        if (!default_targets.empty())
-          default_targets += ' ';
-        default_targets += EscapeBuildTarget(s);
-      }
-    }
-    if (!g_flags.generate_empty_ninja) {
-      out << "\n"
-          << "default " << default_targets << '\n';
     }
   }
 

--- a/testcase/empty_ninja_file.sh
+++ b/testcase/empty_ninja_file.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+# Copyright 2021 Google Inc. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This just tests that kati doesn't crash when using --empty_ninja_file
+
+set -u
+
+mk="$@"
+
+cat <<EOF > Makefile
+result:
+	@echo "Foo" > \$@
+EOF
+
+if echo "${mk}" | grep -qv "kati"; then
+  # Make doesn't support --empty_ninja_file
+  ${mk} --warn 2>&1
+else
+  ${mk} --ninja --empty_ninja_file --warn 2>&1
+fi


### PR DESCRIPTION
This bug was introduced in commit bca0a69ffd7045e33bd2e42e795cc0ade6f81c69.
EmitNode() used to always be called, but after that commit, EmitNode()
is no longer called when using --empty_ninja_file. EmitNode() has the side
effect of setting default_target_, which was then needed later on.

However it turns out that default_target_ is not actually needed when
using --empty_ninja_file, so moving the code that uses it into the check
that that flag is not provided fixes the issue.