### PR TITLE
Switch from vfork to posix_spawn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
-RUN apt-get update && apt-get install -y make git-core build-essential curl ninja-build python
+RUN apt-get update && apt-get install -y make git-core build-essential curl ninja-build python python3
 
 # Install Go
 RUN \
@@ -13,6 +13,7 @@ ENV GOPATH /gopath
 ENV PATH $GOROOT/bin:$GOPATH/bin:$PATH
 
 # Copy project code.
-COPY . /
+COPY . /src
+WORKDIR /src
 
-ENTRYPOINT make test
+CMD make test -j8

--- a/testcase/ninja_mkdir.sh
+++ b/testcase/ninja_mkdir.sh
@@ -16,7 +16,7 @@
 
 set -e
 
-log=/tmp/log
+log=stderr_log
 mk="$@"
 
 cat <<EOF > Makefile

--- a/testcase/ninja_pool.sh
+++ b/testcase/ninja_pool.sh
@@ -16,7 +16,7 @@
 
 set -e
 
-log=/tmp/log
+log=stderr_log
 mk="$@"
 
 cat <<EOF > Makefile

--- a/testcase/ninja_regen.sh
+++ b/testcase/ninja_regen.sh
@@ -16,7 +16,7 @@
 
 set -e
 
-log=/tmp/log
+log=stderr_log
 mk="$@"
 
 export VAR=hoge

--- a/testcase/ninja_regen_filefunc_read.sh
+++ b/testcase/ninja_regen_filefunc_read.sh
@@ -16,7 +16,7 @@
 
 set -e
 
-log=/tmp/log
+log=stderr_log
 mk="$@"
 
 cat <<EOF > Makefile

--- a/testcase/ninja_regen_filefunc_write.sh
+++ b/testcase/ninja_regen_filefunc_write.sh
@@ -16,7 +16,7 @@
 
 set -e
 
-log=/tmp/log
+log=stderr_log
 mk="$@"
 
 cat <<EOF > Makefile

--- a/testcase/ninja_regen_glob.sh
+++ b/testcase/ninja_regen_glob.sh
@@ -16,7 +16,7 @@
 
 set -e
 
-log=/tmp/log
+log=stderr_log
 mk="$@"
 
 touch xe.mk yc.mk xa.mk yb.mk xd.mk


### PR DESCRIPTION
The macOS 12 SDK has deprecated vfork in preference of posix_spawn or fork. Switch to posix_spawn with the flag to continue using vfork on Linux.