### PR TITLE
Fix tests for ubuntu 22.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,27 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
-RUN apt-get update && apt-get install -y make git-core build-essential curl ninja-build python python3
+RUN apt-get update && apt-get install -y make git-core build-essential curl ninja-build python3 wget
 
 # Install Go
 RUN \
   mkdir -p /goroot && \
   curl https://storage.googleapis.com/golang/go1.14.9.linux-amd64.tar.gz | tar xvzf - -C /goroot --strip-components=1
 
-# Set environment variables for Go.
+# Install Make, we emulate Make 4.2.1 instead of the default 4.3 currently
+RUN \
+  mkdir -p /make/tmp && \
+  cd /make/tmp && \
+  wget http://mirrors.kernel.org/ubuntu/pool/main/m/make-dfsg/make_4.2.1-1.2_amd64.deb && \
+  ar xv make_4.2.1-1.2_amd64.deb && \
+  tar xf data.tar.xz && \
+  mv usr/bin/make ../ && \
+  cd .. && \
+  rm -rf tmp/
+
+# Set environment variables for Go and Make.
 ENV GOROOT /goroot
 ENV GOPATH /gopath
-ENV PATH $GOROOT/bin:$GOPATH/bin:$PATH
+ENV PATH $GOROOT/bin:$GOPATH/bin:/make:$PATH
 
 # Copy project code.
 COPY . /src

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,9 @@ info: ckati
 	@echo CKATI VERSION
 	./ckati -f Makefile version
 	@echo
+	@echo BASH VERSION
+	-/bin/bash --version | head -n 1
+	@echo
 	@echo SHELL VERSION
 	@echo $(SHELL)
 	$(SHELL) --version | head -n 1
@@ -33,6 +36,7 @@ version:
 	@echo $(MAKE_VERSION)
 
 test: all ckati_tests
+	go test --ckati
 	go test --ckati --ninja
 
 clean: ckati_clean

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ $ make ckati
 
 The above command produces a `ckati` binary in the project root.
 
-Testing (best ran in a Ubuntu 20.04 environment):
+Testing (best ran in a Ubuntu 22.04 environment):
 
 ```
 $ make test

--- a/run_test.go
+++ b/run_test.go
@@ -69,7 +69,7 @@ var normalizeMakeLog = []normalization{
 	// GNU make 4.0 has this output.
 	{regexp.MustCompile(`Makefile:\d+: commands for target ".*?" failed\n`), ""},
 	// We treat some warnings as errors.
-	{regexp.MustCompile(`/bin/(ba)?sh: line 0: `), ""},
+	{regexp.MustCompile(`/bin/(ba)?sh: line 1: `), ""},
 	// Normalization for "include foo" with C++ kati
 	{regexp.MustCompile(`(: \S+: No such file or directory)\n\*\*\* No rule to make target "[^"]+".`), "$1"},
 	// GNU make 4.0 prints the file:line as part of the error message, e.g.:
@@ -89,7 +89,7 @@ var normalizeKati = []normalization{
 	// kati specific log messages
 	{regexp.MustCompile(`\*kati\*[^\n]*`), ""},
 	{regexp.MustCompile(`c?kati: `), ""},
-	{regexp.MustCompile(`/bin/sh: line 0: `), ""},
+	{regexp.MustCompile(`/bin/(ba)?sh: line 1: `), ""},
 	{regexp.MustCompile(`/bin/sh: `), ""},
 	{regexp.MustCompile(`.*: warning for parse error in an unevaluated line: [^\n]*`), ""},
 	{regexp.MustCompile(`([^\n ]+: )?FindEmulator: `), ""},


### PR DESCRIPTION
The version of bash in ubuntu 22.04 says errors occur on line 1 instead of line 0 when using `bash -c`. Update the tests to handle that.