### PR TITLE
Remove ParserState and IfState pointers

### DIFF
--- a/src/eval.cc
+++ b/src/eval.cc
@@ -553,7 +553,7 @@ void Evaluator::EvalCommand(const CommandStmt* stmt) {
 
   if (!last_rule_) {
     std::vector<Stmt*> stmts;
-    ParseNotAfterRule(stmt->orig, stmt->loc(), &stmts);
+    ParseNoStats(stmt->orig, stmt->loc(), &stmts);
     for (Stmt* a : stmts)
       a->Eval(this);
     return;

--- a/src/parser.h
+++ b/src/parser.h
@@ -25,9 +25,9 @@ class Makefile;
 
 void Parse(Makefile* mk);
 void Parse(std::string_view buf, const Loc& loc, std::vector<Stmt*>* out_asts);
-void ParseNotAfterRule(std::string_view buf,
-                       const Loc& loc,
-                       std::vector<Stmt*>* out_asts);
+void ParseNoStats(std::string_view buf,
+                  const Loc& loc,
+                  std::vector<Stmt*>* out_asts);
 
 void ParseAssignStatement(std::string_view line,
                           size_t sep,


### PR DESCRIPTION
ParserState was never compared to anything
except for NOT_AFTER_RULE, so it could be
a boolean instead.

IfState instances had no reason to be pointers
because they were always accessed from if_stack_.