### PR TITLE
Merge ckati_stamp_dump into the regular ckati binary

### DIFF
--- a/Makefile.ckati
+++ b/Makefile.ckati
@@ -40,6 +40,7 @@ KATI_CXX_SRCS := \
 	ninja.cc \
 	parser.cc \
 	regen.cc \
+	regen_dump.cc \
 	rule.cc \
 	stats.cc \
 	stmt.cc \

--- a/src/Android.bp
+++ b/src/Android.bp
@@ -64,20 +64,16 @@ cc_library_host_static {
 cc_binary_host {
     name: "ckati",
     defaults: ["ckati_defaults"],
-    srcs: ["main.cc"],
+    srcs: [
+        "main.cc",
+        "regen_dump.cc",
+    ],
     whole_static_libs: ["libckati"],
     target: {
         linux_glibc: {
-            shared_libs: ["libjemalloc"],
+            shared_libs: ["libjemalloc5"],
         },
     },
-}
-
-cc_binary_host {
-    name: "ckati_stamp_dump",
-    defaults: ["ckati_defaults"],
-    srcs: ["regen_dump.cc"],
-    static_libs: ["libckati"],
 }
 
 cc_test_host {
@@ -87,7 +83,6 @@ cc_test_host {
     srcs: [
         "find_test.cc",
         "ninja_test.cc",
-        "strutil_bench.cc",
         "strutil_test.cc",
     ],
     gtest: false,
@@ -99,6 +94,15 @@ cc_benchmark_host {
     defaults: ["ckati_defaults"],
     srcs: [
         "fileutil_bench.cc",
+    ],
+    static_libs: ["libckati"],
+}
+
+cc_test_host {
+    name: "ckati_strutil_bench",
+    defaults: ["ckati_defaults"],
+    srcs: [
+        "strutil_bench.cc",
     ],
     static_libs: ["libckati"],
 }

--- a/src/main.cc
+++ b/src/main.cc
@@ -37,6 +37,7 @@
 #include "ninja.h"
 #include "parser.h"
 #include "regen.h"
+#include "regen_dump.h"
 #include "stats.h"
 #include "stmt.h"
 #include "stringprintf.h"
@@ -354,9 +355,17 @@ static void HandleRealpath(int argc, char** argv) {
 }
 
 int main(int argc, char* argv[]) {
-  if (argc >= 2 && !strcmp(argv[1], "--realpath")) {
-    HandleRealpath(argc - 2, argv + 2);
-    return 0;
+  if (argc >= 2) {
+    if (!strcmp(argv[1], "--realpath")) {
+      HandleRealpath(argc - 2, argv + 2);
+      return 0;
+    } else if (!strcmp(argv[1], "--dump_stamp_tool")) {
+      // Unfortunately, this can easily be confused with --dump_kati_stamp,
+      // which prints debug info about the stamp while executing a normal kati
+      // run. This tool flag only dumps information, and doesn't run the rest of
+      // kati.
+      return stamp_dump_main(argc, argv);
+    }
   }
   std::string orig_args;
   for (int i = 0; i < argc; i++) {

--- a/src/regen_dump.cc
+++ b/src/regen_dump.cc
@@ -29,9 +29,7 @@
 #include "log.h"
 #include "strutil.h"
 
-using namespace std;
-
-vector<std::string> LoadVecString(FILE* fp) {
+std::vector<std::string> LoadVecString(FILE* fp) {
   int count = LoadInt(fp);
   if (count < 0) {
     ERROR("Incomplete stamp file");
@@ -45,21 +43,22 @@ vector<std::string> LoadVecString(FILE* fp) {
   return ret;
 }
 
-int main(int argc, char* argv[]) {
+int stamp_dump_main(int argc, char* argv[]) {
   bool dump_files = false;
   bool dump_env = false;
   bool dump_globs = false;
   bool dump_cmds = false;
   bool dump_finds = false;
 
-  if (argc == 1) {
-    fprintf(stderr,
-            "Usage: ckati_stamp_dump [--env] [--files] [--globs] [--cmds] "
-            "[--finds] <stamp>\n");
+  if (argc <= 2) {
+    fprintf(
+        stderr,
+        "Usage: ckati --dump_stamp_tool [--env] [--files] [--globs] [--cmds] "
+        "[--finds] <stamp>\n");
     return 1;
   }
 
-  for (int i = 1; i < argc - 1; i++) {
+  for (int i = 2; i < argc - 1; i++) {
     const char* arg = argv[i];
     if (!strcmp(arg, "--env")) {
       dump_env = true;
@@ -72,7 +71,7 @@ int main(int argc, char* argv[]) {
     } else if (!strcmp(arg, "--finds")) {
       dump_finds = true;
     } else {
-      fprintf(stderr, "Unknown option: %s", arg);
+      fprintf(stderr, "Unknown option: %s\n", arg);
       return 1;
     }
   }
@@ -83,7 +82,7 @@ int main(int argc, char* argv[]) {
 
   FILE* fp = fopen(argv[argc - 1], "rb");
   if (!fp)
-    PERROR("fopen");
+    PERROR(argv[argc - 1]);
 
   ScopedFile sfp(fp);
   double gen_time;
@@ -117,8 +116,8 @@ int main(int argc, char* argv[]) {
   if (num_envs < 0)
     ERROR("Incomplete stamp file");
   for (int i = 0; i < num_envs; i++) {
-    string name;
-    string val;
+    std::string name;
+    std::string val;
     if (!LoadString(fp, &name))
       ERROR("Incomplete stamp file");
     if (!LoadString(fp, &val))
@@ -131,7 +130,7 @@ int main(int argc, char* argv[]) {
   if (num_globs < 0)
     ERROR("Incomplete stamp file");
   for (int i = 0; i < num_globs; i++) {
-    string pat;
+    std::string pat;
     if (!LoadString(fp, &pat))
       ERROR("Incomplete stamp file");
 
@@ -150,7 +149,7 @@ int main(int argc, char* argv[]) {
     ERROR("Incomplete stamp file");
   for (int i = 0; i < num_cmds; i++) {
     CommandOp op = static_cast<CommandOp>(LoadInt(fp));
-    string shell, shellflag, cmd, result, file;
+    std::string shell, shellflag, cmd, result, file;
     if (!LoadString(fp, &shell))
       ERROR("Incomplete stamp file");
     if (!LoadString(fp, &shellflag))

--- a/src/regen_dump.h
+++ b/src/regen_dump.h
@@ -1,0 +1,22 @@
+// Copyright 2016 Google Inc. All rights reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef REGEN_DUMP_H_
+#define REGEN_DUMP_H_
+
+#include <string>
+
+int stamp_dump_main(int argc, char* argv[]);
+
+#endif  // REGEN_DUMP_H_


### PR DESCRIPTION
So that there's fewer binaries to worry about updating. There's only 1 actual usage of ckati_stamp_dump in android, so it should be easy to update it when we update ckati in android.