### PR TITLE
Add KATI_extra_file_deps and KATI_shell_no_rerun

### DIFF
--- a/src/file_cache.cc
+++ b/src/file_cache.cc
@@ -19,30 +19,28 @@
 #include "file.h"
 #include "file_cache.h"
 
-MakefileCacheManager::MakefileCacheManager() = default;
-
-MakefileCacheManager::~MakefileCacheManager() = default;
-
-class MakefileCacheManagerImpl : public MakefileCacheManager {
- public:
-  virtual const Makefile& ReadMakefile(const std::string& filename) override {
-    auto iter = cache_.find(filename);
-    if (iter != cache_.end()) {
-      return iter->second;
-    }
-    return (cache_.emplace(filename, filename).first)->second;
+const Makefile& MakefileCacheManager::ReadMakefile(
+    const std::string& filename) {
+  auto iter = cache_.find(filename);
+  if (iter != cache_.end()) {
+    return iter->second;
   }
+  return (cache_.emplace(filename, filename).first)->second;
+}
 
-  virtual void GetAllFilenames(std::unordered_set<std::string>* out) override {
-    for (const auto& p : cache_)
-      out->insert(p.first);
-  }
+void MakefileCacheManager::GetAllFilenames(
+    std::unordered_set<std::string>* out) {
+  for (const auto& p : cache_)
+    out->insert(p.first);
+  for (const auto& f : extra_file_deps_)
+    out->insert(f);
+}
 
- private:
-  std::unordered_map<std::string, Makefile> cache_;
-};
+void MakefileCacheManager::AddExtraFileDep(std::string_view dep) {
+  extra_file_deps_.emplace(dep);
+}
 
 MakefileCacheManager& MakefileCacheManager::Get() {
-  static MakefileCacheManagerImpl instance;
+  static MakefileCacheManager instance;
   return instance;
 }

--- a/src/file_cache.h
+++ b/src/file_cache.h
@@ -22,15 +22,18 @@ class Makefile;
 
 class MakefileCacheManager {
  public:
-  virtual ~MakefileCacheManager();
-
-  virtual const Makefile& ReadMakefile(const std::string& filename) = 0;
-  virtual void GetAllFilenames(std::unordered_set<std::string>* out) = 0;
+  const Makefile& ReadMakefile(const std::string& filename);
+  void GetAllFilenames(std::unordered_set<std::string>* out);
+  void AddExtraFileDep(std::string_view dep);
 
   static MakefileCacheManager& Get();
 
- protected:
-  MakefileCacheManager();
+ private:
+  MakefileCacheManager() = default;
+  MakefileCacheManager(const MakefileCacheManager&) = delete;
+  MakefileCacheManager(MakefileCacheManager&&) = delete;
+  std::unordered_map<std::string, Makefile> cache_;
+  std::unordered_set<std::string> extra_file_deps_;
 };
 
 #endif  // FILE_CACHE_H_

--- a/src/regen.cc
+++ b/src/regen.cc
@@ -161,7 +161,9 @@ class StampChecker {
     for (int i = 0; i < num_files; i++) {
       LOAD_STRING(fp, &s);
       double ts = GetTimestamp(s);
-      if (gen_time < ts) {
+      // GetTimestamp returns < 0 when there's an error reading the file, like
+      // when its been removed.
+      if (gen_time < ts || ts < 0) {
         if (g_flags.regen_ignoring_kati_binary) {
           if (s == GetExecutablePath()) {
             fprintf(stderr, "%s was modified, ignored.\n", s.c_str());

--- a/testcase/ninja_regen_extra_file_deps.sh
+++ b/testcase/ninja_regen_extra_file_deps.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+#
+# Copyright 2023 Google Inc. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+log=stderr_log
+mk="$@"
+
+touch a.txt b.txt
+
+cat <<EOF > Makefile
+EXTRA_DEPS := a.txt b.txt
+\$(KATI_extra_file_deps \$(EXTRA_DEPS))
+all:
+	echo foo
+EOF
+
+${mk} 2> ${log}
+if [ -e ninja.sh ]; then
+  ./ninja.sh
+fi
+
+${mk} 2> ${log}
+if [ -e ninja.sh ]; then
+  if grep -q regenerating ${log}; then
+    echo 'Should not be regenerated'
+  fi
+  ./ninja.sh
+fi
+
+touch a.txt
+
+${mk} 2> ${log}
+if [ -e ninja.sh ]; then
+  if ! grep -q regenerating ${log}; then
+    echo 'Should have regenerated due to touched file'
+  fi
+  ./ninja.sh
+fi
+
+rm a.txt
+
+# Ignore the error about a.txt missing on this run, we only care that kati tried to regenerate
+${mk} 2> ${log} || true
+if [ -e ninja.sh ]; then
+  if ! grep -q regenerating ${log}; then
+    echo 'Should have regenerated due to removed file'
+  fi
+  ./ninja.sh
+fi

--- a/testcase/ninja_regen_extra_file_deps_error_on_missing_file.sh
+++ b/testcase/ninja_regen_extra_file_deps_error_on_missing_file.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+#
+# Copyright 2023 Google Inc. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+log=stderr_log
+mk="$@"
+
+cat <<EOF > Makefile
+\$(KATI_extra_file_deps a.txt)
+all:
+	echo foo
+EOF
+
+${mk} 2> ${log} || true
+if echo "${mk}" | grep -q kati; then
+  if grep -q "file does not exist: a.txt" ${log}; then
+    echo 'foo'
+  else
+    echo 'Expected a missing file error message'
+  fi
+fi

--- a/testcase/ninja_shell_no_rerun.sh
+++ b/testcase/ninja_shell_no_rerun.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+#
+# Copyright 2023 Google Inc. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+log=stderr_log
+mk="$@"
+
+echo foo > a.txt
+
+if echo "${mk}" | grep -q kati; then
+  cat <<EOF > Makefile
+RESULT := \$(KATI_shell_no_rerun cat a.txt)
+all:
+	echo \$(RESULT)
+EOF
+else
+  cat <<EOF > Makefile
+RESULT := \$(shell cat a.txt)
+all:
+	echo \$(RESULT)
+EOF
+fi
+
+${mk} 2> ${log}
+if [ -e ninja.sh ]; then
+  ./ninja.sh
+fi
+
+# Only change the file for kati so that make matches kati's broken output of printing foo 2 times.
+# ("broken" because the user forgot to add a.txt to $(KATI_extra_file_deps))
+if echo "${mk}" | grep -q kati; then
+echo bar > a.txt
+fi
+
+${mk} 2> ${log}
+if [ -e ninja.sh ]; then
+  if grep -q regenerating ${log}; then
+    echo 'Should not be regenerated'
+  fi
+  ./ninja.sh
+fi

--- a/testcase/ninja_shell_no_rerun_error_in_rule.sh
+++ b/testcase/ninja_shell_no_rerun_error_in_rule.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+#
+# Copyright 2023 Google Inc. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eu
+
+log=stderr_log
+mk="$@"
+
+echo foo > a.txt
+
+if echo "${mk}" | grep -q kati; then
+  cat <<EOF > Makefile
+all:
+	echo \$(KATI_shell_no_rerun echo foo)
+EOF
+else
+  cat <<EOF > Makefile
+all:
+	echo foo
+EOF
+fi
+
+${mk} 2> ${log} || true
+if grep -q "KATI_shell_no_rerun provides no benefit over regular \$(shell) inside of a rule" ${log}; then
+  echo foo
+fi


### PR DESCRIPTION
We want to add the ability for kati to injest starlark code to android, but we don't want starlark to rerun on every invocation of kati. Instead, add a `$(KATI_shell_no_rerun)` that will run the shell command when kati regenerates the ninja file, but not when checking the stamp file. Then, the starlark files can be added as dependencies with `$(KATI_extra_file_deps)`.
