### PR TITLE
Add foreach_sep and KATI_file_no_rerun functions

### DIFF
--- a/src/expr.cc
+++ b/src/expr.cc
@@ -215,7 +215,7 @@ class VarSubst : public Value {
     WordWriter ww(s);
     Pattern pat(pat_str);
     for (std::string_view tok : WordScanner(value)) {
-      ww.MaybeAddWhitespace();
+      ww.MaybeAddSeparator();
       pat.AppendSubstRef(tok, subst, s);
     }
   }

--- a/src/strutil.cc
+++ b/src/strutil.cc
@@ -83,16 +83,16 @@ void WordScanner::Split(std::vector<std::string_view>* o) {
 
 WordWriter::WordWriter(std::string* o) : out_(o), needs_space_(false) {}
 
-void WordWriter::MaybeAddWhitespace() {
+void WordWriter::MaybeAddSeparator(std::string_view sep) {
   if (needs_space_) {
-    out_->push_back(' ');
+    out_->append(sep);
   } else {
     needs_space_ = true;
   }
 }
 
 void WordWriter::Write(std::string_view s) {
-  MaybeAddWhitespace();
+  MaybeAddSeparator();
   out_->append(s);
 }
 

--- a/src/strutil.h
+++ b/src/strutil.h
@@ -47,7 +47,7 @@ class WordScanner {
 class WordWriter {
  public:
   explicit WordWriter(std::string* o);
-  void MaybeAddWhitespace();
+  void MaybeAddSeparator(std::string_view sep = " ");
   void Write(std::string_view s);
 
  private:

--- a/testcase/foreach.mk
+++ b/testcase/foreach.mk
@@ -1,7 +1,15 @@
 base := base
 dirs := a b c d
 dir := FAIL
+comma := ,
 files := $(foreach dir,$(dirs),$(foreach subdir,$(dirs),$(dir)/$(subdir)/$(base)))
+ifdef KATI
+files2 := $(KATI_foreach_sep dir,$(comma) ,$(dirs),"$(dir)")
+else
+# Since make doesn't have the function, manually set the result.
+files2 := "a", "b", "c", "d"
+endif
 
 test:
 	echo $(files)
+	echo $(files2)

--- a/testcase/ninja_file_no_rerun_func.sh
+++ b/testcase/ninja_file_no_rerun_func.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+#
+# Copyright 2023 Google Inc. All rights reserved
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+log=stderr_log
+mk="$@"
+
+echo "PASS" >testfile
+
+cat <<EOF > Makefile
+ifdef KATI
+SUPPORTS_FILE := 1
+endif
+ifneq (,\$(filter 4.2%,\$(MAKE_VERSION)))
+SUPPORTS_FILE := 1
+endif
+
+ifdef KATI
+  \$(KATI_file_no_rerun >testwrite,PASS)
+  RESULT := \$(KATI_file_no_rerun <testwrite)
+else
+ifdef SUPPORTS_FILE
+  \$(file >testwrite,PASS)
+  RESULT := \$(file <testwrite)
+else
+  # Make <4 does not support \$(file ...)
+  \$(info Read back: PASS)
+  RESULT := PASS
+endif
+endif
+
+all: ;@echo \$(RESULT)
+EOF
+
+${mk} 2> ${log}
+if [ -e ninja.sh ]; then
+  ./ninja.sh
+fi
+
+${mk} 2> ${log}
+if [ -e ninja.sh ]; then
+  if grep -q regenerating ${log}; then
+    echo 'Should not be regenerated'
+  fi
+  ./ninja.sh
+fi


### PR DESCRIPTION
These changes both allow us to remove otherwise unnecessary invocations of the shell.

 - foreach_sep helps with creating variables containing json strings.
 - KATI_file_no_rerun avoids rewriting on every invocation.