### PR TITLE
Add arbitrary metadata "tag" tracking.

### DIFF
--- a/src/dep.cc
+++ b/src/dep.cc
@@ -286,7 +286,8 @@ DepNode::DepNode(Symbol o, bool p, bool r)
       is_restat(r),
       rule_vars(NULL),
       depfile_var(NULL),
-      ninja_pool_var(NULL) {}
+      ninja_pool_var(NULL),
+      tags_var(NULL) {}
 
 class DepBuilder {
  public:
@@ -300,7 +301,8 @@ class DepBuilder {
         implicit_outputs_var_name_(Intern(".KATI_IMPLICIT_OUTPUTS")),
         symlink_outputs_var_name_(Intern(".KATI_SYMLINK_OUTPUTS")),
         ninja_pool_var_name_(Intern(".KATI_NINJA_POOL")),
-        validations_var_name_(Intern(".KATI_VALIDATIONS")) {
+        validations_var_name_(Intern(".KATI_VALIDATIONS")),
+        tags_var_name_(Intern(".KATI_TAGS")) {
     ScopedTimeReporter tr("make dep (populate)");
     PopulateRules(rules);
     // TODO?
@@ -735,6 +737,8 @@ class DepBuilder {
         } else if (name == validations_var_name_) {
         } else if (name == ninja_pool_var_name_) {
           n->ninja_pool_var = new_var;
+        } else if (name == tags_var_name_) {
+          n->tags_var = new_var;
         } else {
           sv.emplace_back(new ScopedVar(cur_rule_vars_.get(), name, new_var));
         }
@@ -941,6 +945,7 @@ class DepBuilder {
   Symbol symlink_outputs_var_name_;
   Symbol ninja_pool_var_name_;
   Symbol validations_var_name_;
+  Symbol tags_var_name_;
 };
 
 void MakeDep(Evaluator* ev,

--- a/src/dep.h
+++ b/src/dep.h
@@ -53,6 +53,7 @@ struct DepNode {
   Vars* rule_vars;
   Var* depfile_var;
   Var* ninja_pool_var;
+  Var* tags_var;
   Symbol output_pattern;
   Loc loc;
 };

--- a/src/ninja.cc
+++ b/src/ninja.cc
@@ -604,6 +604,13 @@ class NinjaGenerator {
     if (node->is_phony && g_flags.use_ninja_phony_output) {
       out << " phony_output = true\n";
     }
+    if (node->tags_var) {
+      std::string tags;
+      node->tags_var->Eval(ev_, &tags);
+      if (!tags.empty()) {
+        out << " tags = " << tags << "\n";
+      }
+    }
     if (node->is_default_target) {
       std::unique_lock<std::mutex> lock(mu_);
       default_target_ = node;


### PR DESCRIPTION
Allows makefiles to set the `.KATI_TAGS` target specific variable to annotate arbitrary metadata for the build step for use in profiling.

Bug: http://b/259130368
Test: end-to-end test tracing the time spent running cp for dist
Change-Id: I930a828cc09add1ce13f7e23142e208c9a7ca5fc