### PR TITLE
Fix CI and enable ninja-validations.sh

### DIFF
--- a/.github/workflows/cpp-ci.yml
+++ b/.github/workflows/cpp-ci.yml
@@ -11,11 +11,11 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     env:
-      CXX: clang++-12
-      CLANG_FORMAT: clang-format-12
+      CXX: clang++-14
+      CLANG_FORMAT: clang-format-14
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/cpp-ci.yml
+++ b/.github/workflows/cpp-ci.yml
@@ -22,7 +22,7 @@ jobs:
     - name: install ninja
       run: |
         mkdir -p ${GITHUB_WORKSPACE}/ninja-bin; cd ${GITHUB_WORKSPACE}/ninja-bin
-        wget https://github.com/ninja-build/ninja/releases/download/v1.10.2/ninja-linux.zip
+        wget https://github.com/ninja-build/ninja/releases/download/v1.11.1/ninja-linux.zip
         unzip ninja-linux.zip
         rm ninja-linux.zip
         echo "${GITHUB_WORKSPACE}/ninja-bin" >> "$GITHUB_PATH"

--- a/run_test.go
+++ b/run_test.go
@@ -240,10 +240,13 @@ func runKatiInScript(t *testing.T, script, dir string, isNinjaTest bool) string 
 	}
 	args = append(args, "SHELL=/bin/bash")
 
+	var stderrb bytes.Buffer
 	cmd := exec.Command(args[0], args[1:]...)
 	cmd.Dir = dir
+	cmd.Stderr = &stderrb
 	output, _ := cmd.Output()
 	write("stdout", output)
+	write("stderr", stderrb.Bytes())
 	if isNinjaTest {
 		output = normalize(output, normalizeNinja)
 	}

--- a/src/file_cache.h
+++ b/src/file_cache.h
@@ -18,7 +18,7 @@
 #include <string>
 #include <unordered_set>
 
-class Makefile;
+#include "file.h"
 
 class MakefileCacheManager {
  public:

--- a/src/func.cc
+++ b/src/func.cc
@@ -1086,7 +1086,9 @@ void ExtraFileDepsFunc(const std::vector<Value*>& args,
 
 #define ENTRY(name, args...) \
   {                          \
-    name, { name, args }     \
+    name, {                  \
+      name, args             \
+    }                        \
   }
 
 static const std::unordered_map<std::string_view, FuncInfo> g_func_info_map = {

--- a/testcase/ninja_validations.sh
+++ b/testcase/ninja_validations.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# TODO(ninja): enable once upstream ninja supports validations
 #
 # Copyright 2015 Google Inc. All rights reserved
 #


### PR DESCRIPTION
CI was broken due to updates to the ubuntu docker image.

ninja-validations.sh can be enabled by updating ninja to the latest verision.
