### PR TITLE
Add func KATI_visibility_prefix

### DIFF
--- a/src/expr.cc
+++ b/src/expr.cc
@@ -146,6 +146,7 @@ class SymRef : public Value {
     Var* v = ev->LookupVarForEval(name_);
     v->Used(ev, name_);
     v->Eval(ev, s);
+    v->CheckCurrentReferencingFile(ev->loc(), name_.c_str());
     ev->VarEvalComplete(name_);
   }
 
@@ -176,6 +177,7 @@ class VarRef : public Value {
     Var* v = ev->LookupVarForEval(sym);
     v->Used(ev, sym);
     v->Eval(ev, s);
+    v->CheckCurrentReferencingFile(ev->loc(), name.c_str());
     ev->VarEvalComplete(sym);
   }
 

--- a/src/find.cc
+++ b/src/find.cc
@@ -28,7 +28,7 @@
 #include <string_view>
 #include <vector>
 
-//#undef NOLOG
+// #undef NOLOG
 
 #include "fileutil.h"
 #include "log.h"

--- a/src/strutil.cc
+++ b/src/strutil.cc
@@ -110,6 +110,11 @@ bool HasPrefix(std::string_view str, std::string_view prefix) {
   return size_diff >= 0 && str.substr(0, prefix.size()) == prefix;
 }
 
+bool HasPathPrefix(std::string_view str, std::string_view prefix) {
+  return HasPrefix(str, prefix) &&
+         (str.size() == prefix.size() || str.at(prefix.size()) == '/');
+}
+
 bool HasSuffix(std::string_view str, std::string_view suffix) {
   ssize_t size_diff = str.size() - suffix.size();
   return size_diff >= 0 && str.substr(size_diff) == suffix;

--- a/src/strutil.h
+++ b/src/strutil.h
@@ -80,6 +80,11 @@ inline std::string JoinStrings(std::vector<String> v, const char* sep) {
 
 bool HasPrefix(std::string_view str, std::string_view prefix);
 
+// Checks path-like prefixes. str and prefix and both considered as strings
+// that represent "path".
+// e.g. str "foo/bar" has path prefix "foo" but doesn't have path prefix "fo".
+bool HasPathPrefix(std::string_view str, std::string_view prefix);
+
 bool HasSuffix(std::string_view str, std::string_view suffix);
 
 bool HasWord(std::string_view str, std::string_view w);

--- a/src/symtab.cc
+++ b/src/symtab.cc
@@ -14,7 +14,7 @@
 
 // +build ignore
 
-//#define ENABLE_TID_CHECK
+// #define ENABLE_TID_CHECK
 
 #include "symtab.h"
 

--- a/src/var.h
+++ b/src/var.h
@@ -73,6 +73,13 @@ class Var : public Evaluable {
   bool SelfReferential() const { return self_referential_; }
   void SetSelfReferential() { self_referential_ = true; }
 
+  const std::vector<std::string>& VisibilityPrefix() const {
+    return visibility_prefix_;
+  }
+  void SetVisibilityPrefix(const std::vector<std::string>& prefixes,
+                           const char* name);
+  void CheckCurrentReferencingFile(Loc loc, const char* name);
+
   const std::string& DeprecatedMessage() const;
 
   // This variable was used (either written or read from)
@@ -101,6 +108,8 @@ class Var : public Evaluable {
   const char* diagnostic_message_text() const;
 
   static std::unordered_map<const Var*, std::string> diagnostic_messages_;
+
+  std::vector<std::string> visibility_prefix_;
 };
 
 class SimpleVar : public Var {

--- a/testcase/var_visibility_prefix_conflict.mk
+++ b/testcase/var_visibility_prefix_conflict.mk
@@ -1,0 +1,16 @@
+FOO := foo
+BAR := bar
+PREFIX := pone/ptwo
+
+$(KATI_visibility_prefix FOO, pone/ptwo baz)
+$(KATI_visibility_prefix FOO, $(PREFIX) baz)
+
+$(KATI_visibility_prefix BAR, pone/ptwo baz)
+$(KATI_visibility_prefix BAR, baz $(PREFIX))
+
+ifndef KATI
+$(info Visibility prefix conflict on variable: BAR)
+endif
+
+test:
+	@:

--- a/testcase/var_visibility_prefix_implicit_define.mk
+++ b/testcase/var_visibility_prefix_implicit_define.mk
@@ -1,0 +1,6 @@
+$(KATI_visibility_prefix FOO, Makefile)
+
+BAR := $(FOO)
+
+test:
+	echo '$(BAR)'

--- a/testcase/var_visibility_prefix_invalid_file_four.mk
+++ b/testcase/var_visibility_prefix_invalid_file_four.mk
@@ -1,0 +1,16 @@
+$(KATI_visibility_prefix BAR, bar)
+FOO = $(BAR) # this should be okay, since it's not evaluated
+BAZ := $(FOO)
+
+define ERROR_MSG
+Makefile is not a valid file to reference variable BAR. Line #3.
+Valid file prefixes:
+bar
+endef
+
+ifndef KATI
+$(info $(ERROR_MSG))
+endif
+
+test:
+	@:

--- a/testcase/var_visibility_prefix_invalid_file_one.mk
+++ b/testcase/var_visibility_prefix_invalid_file_one.mk
@@ -1,0 +1,23 @@
+FOO := foo
+BAR := bar
+$(KATI_visibility_prefix FOO, Makefile)
+$(KATI_visibility_prefix BAR, )
+$(KATI_visibility_prefix BAZ, baz)
+
+VAR0 := $(FOO)
+VAR1 := $(BAR)
+VAR2 := $$(BAZ)
+VAR3 := $($(BAZ))
+
+define ERROR_MSG
+Makefile is not a valid file to reference variable BAZ. Line #10.
+Valid file prefixes:
+baz
+endef
+
+ifndef KATI
+$(info $(ERROR_MSG))
+endif
+
+test:
+	@:

--- a/testcase/var_visibility_prefix_invalid_file_two.mk
+++ b/testcase/var_visibility_prefix_invalid_file_two.mk
@@ -1,0 +1,16 @@
+$(KATI_visibility_prefix BAR, bar)
+FOO := BAR
+BAZ := $($(FOO))
+
+define ERROR_MSG
+Makefile is not a valid file to reference variable BAR. Line #3.
+Valid file prefixes:
+bar
+endef
+
+ifndef KATI
+$(info $(ERROR_MSG))
+endif
+
+test:
+	@:

--- a/testcase/var_visibility_prefix_invalid_prefix_four.mk
+++ b/testcase/var_visibility_prefix_invalid_prefix_four.mk
@@ -1,0 +1,8 @@
+$(KATI_visibility_prefix FOO, foo/)
+
+ifndef KATI
+$(info Makefile:1: Visibility prefix foo/ is not normalized. Normalized prefix: foo)
+endif
+
+test:
+	@:

--- a/testcase/var_visibility_prefix_invalid_prefix_one.mk
+++ b/testcase/var_visibility_prefix_invalid_prefix_one.mk
@@ -1,0 +1,8 @@
+$(KATI_visibility_prefix FOO, /foo)
+
+ifndef KATI
+$(info Makefile:1: Visibility prefix should not start with /)
+endif
+
+test:
+	@:

--- a/testcase/var_visibility_prefix_invalid_prefix_three.mk
+++ b/testcase/var_visibility_prefix_invalid_prefix_three.mk
@@ -1,0 +1,9 @@
+$(KATI_visibility_prefix FOO, foo fo) # no error, different path prefixes
+$(KATI_visibility_prefix Bar, bar/baz bar)
+
+ifndef KATI
+$(info Makefile:2: Visibility prefix bar is the prefix of another visibility prefix bar/baz)
+endif
+
+test:
+	@:

--- a/testcase/var_visibility_prefix_invalid_prefix_two.mk
+++ b/testcase/var_visibility_prefix_invalid_prefix_two.mk
@@ -1,0 +1,8 @@
+$(KATI_visibility_prefix FOO, foo ../foo)
+
+ifndef KATI
+$(info Makefile:1: Visibility prefix should not start with ../)
+endif
+
+test:
+	@:


### PR DESCRIPTION
syntax: $(KATI_visibility_prefix var, prefix)

1. Add a func KATI_visibility_prefix that takes a variable name and a list of strings, set this variable's visibility to these strings. Each string represents the relative path from the root, and is considered as prefix.

e.g. $(KATI_visibility_prefix VAR, vendor/ device/b baz.mk) --> VAR is visible to "vendor/foo.mk", "device/bar.mk", "device/baz.mk", "baz.mk", but not visible to "bar.mk", "vendor.mk" or "vendor/baz.mk".

If variable visibility is set more than once, and with a different list of strings, an error will occur.

2. When a variable is being referenced, if this variable has visibility prefix set, check if the current referencing file matches the visibility prefix. Throw an error if not.

3. In $(KATI_visibility_prefix FOO, prefix):
    If FOO is not defined, create a variable FOO with empty value. 
    The prefix can also be reference to variable. If so, this function will expand the reference and set the visibility_prefix.