### PR TITLE
Add missing algorithm header file for eval.cc

### DIFF
--- a/src/eval.cc
+++ b/src/eval.cc
@@ -16,6 +16,7 @@
 
 #include "eval.h"
 
+#include <algorithm>
 #include <ctype.h>
 #include <errno.h>
 #include <pthread.h>


### PR DESCRIPTION
Fix the following build bug.

```
g++ -c -std=c++17 -g -W -Wall -MMD -MP -O -DNOLOG -march=native -o out/eval.o src/eval.cc
src/eval.cc: In member function ‘void Evaluator::EvalIf(const IfStmt*)’:
src/eval.cc:579:16: error: ‘find_if’ is not a member of ‘std’
  579 |           std::find_if(s.begin(), s.end(), ::isspace) != s.end()) {
      |                ^~~~~~~
*** [out/eval.o] Error 1
```
