### PR TITLE
Rust: Lints, Android.bp, etc

### DIFF
--- a/.github/workflows/cpp-ci.yml
+++ b/.github/workflows/cpp-ci.yml
@@ -65,6 +65,8 @@ jobs:
       run: cargo test
     - name: check rustfmt
       run: cargo fmt --check
+    - name: run clippy
+      run: cargo clippy
     - name: run standalone tests with rkati
       run: go test --rkati
     - name: run ninja tests with rkati

--- a/Android.bp
+++ b/Android.bp
@@ -1,0 +1,52 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+rust_defaults {
+    name: "rkati_defaults",
+    edition: "2024",
+    lints: "android",
+    clippy_lints: "android",
+    rustlibs: [
+        "libanyhow",
+        "libbytes",
+        "liblibc",
+        "liblog_rust",
+        "libmemchr",
+        "libos_pipe",
+        "libparking_lot",
+    ],
+}
+
+rust_library_host {
+    name: "libkati",
+    crate_name: "kati",
+    defaults: ["rkati_defaults"],
+    srcs: ["src-rs/lib.rs"],
+}
+
+rust_binary_host {
+    name: "rkati",
+    defaults: ["rkati_defaults"],
+    srcs: ["src-rs/main.rs"],
+    rustlibs: [
+        "libkati",
+        "libenv_logger",
+    ],
+}
+
+rust_test_host {
+    name: "rkati_unit_tests",
+    defaults: ["rkati_defaults"],
+    srcs: ["src-rs/lib.rs"],
+}

--- a/src-rs/command.rs
+++ b/src-rs/command.rs
@@ -95,7 +95,7 @@ impl AutoCommandVar {
                 out.put_slice(&current_dep_node.output.as_bytes());
             }
             AutoCommand::Less => {
-                if let Some(ai) = current_dep_node.actual_inputs.get(0) {
+                if let Some(ai) = current_dep_node.actual_inputs.first() {
                     out.put_slice(&ai.as_bytes());
                 }
             }
@@ -217,7 +217,7 @@ impl<'a> CommandEvaluator<'a> {
     pub fn new(ev: &'a mut Evaluator) -> Result<Self> {
         let found_new_inputs = Arc::new(Mutex::new(false));
         let mut ret = Self {
-            ev: ev,
+            ev,
             current_dep_node: Arc::new(Mutex::new(None)),
             found_new_inputs: found_new_inputs.clone(),
         };
@@ -250,7 +250,7 @@ impl<'a> CommandEvaluator<'a> {
             sym,
             AutoCommandVar {
                 typ: a.clone(),
-                sym: sym,
+                sym,
                 variant: AutoCommandVariant::D,
                 current_dep_node: self.current_dep_node.clone(),
             },
@@ -261,7 +261,7 @@ impl<'a> CommandEvaluator<'a> {
             sym,
             AutoCommandVar {
                 typ: a,
-                sym: sym,
+                sym,
                 variant: AutoCommandVariant::F,
                 current_dep_node: self.current_dep_node.clone(),
             },
@@ -334,6 +334,6 @@ impl<'a> CommandEvaluator<'a> {
         self.ev.current_scope = None;
         self.ev.is_evaluating_command = false;
 
-        return Ok(result);
+        Ok(result)
     }
 }

--- a/src-rs/dep.rs
+++ b/src-rs/dep.rs
@@ -538,9 +538,7 @@ impl<'a> DepBuilder<'a> {
     }
 
     fn get_rule_inputs(&self, s: Symbol) -> Option<(Vec<Symbol>, Loc)> {
-        let Some(merger) = self.rules.get(&s) else {
-            return None;
-        };
+        let merger = self.rules.get(&s)?;
         let merger = merger.lock();
         let mut ret = Vec::new();
         assert!(!merger.rules.is_empty());
@@ -718,7 +716,7 @@ impl<'a> DepBuilder<'a> {
                 }
             }
         }
-        let Some(matched) = matched else { return None };
+        let matched = matched?;
 
         let mut rule = rule.clone();
         if rule.output_patterns.len() > 1 {
@@ -914,8 +912,9 @@ impl<'a> DepBuilder<'a> {
 
                 if *name == self.depfile_var_name {
                     n.lock().depfile_var = Some(new_var);
-                } else if *name == self.implicit_outputs_var_name {
-                } else if *name == self.validations_var_name {
+                } else if *name == self.implicit_outputs_var_name
+                    || *name == self.validations_var_name
+                {
                 } else if *name == self.ninja_pool_var_name {
                     n.lock().ninja_pool_var = Some(new_var);
                 } else if *name == self.tags_var_name {

--- a/src-rs/eval.rs
+++ b/src-rs/eval.rs
@@ -512,7 +512,7 @@ impl Evaluator {
     //   <before_term> <term> <after_term>
     // parses <before_term> into Symbol instances until encountering ':'
     // Returns the remainder of <before_term>.
-    pub fn parse_rule_targets<'a>(
+    pub fn parse_rule_targets(
         loc: &Loc,
         before_term: &Bytes,
     ) -> Result<(Bytes, Vec<Symbol>, bool)> {

--- a/src-rs/exec.rs
+++ b/src-rs/exec.rs
@@ -155,7 +155,7 @@ impl<'a> Executor<'a> {
             if !FLAGS.is_dry_run {
                 let (status, output) = run_command(
                     &self.shell,
-                    &self.shellflag,
+                    self.shellflag,
                     &command.cmd,
                     RedirectStderr::Stdout,
                 )?;

--- a/src-rs/expr.rs
+++ b/src-rs/expr.rs
@@ -91,7 +91,7 @@ impl Evaluable for Value {
                 }
             }
             Value::SymRef(_, sym) => {
-                let sym = sym.clone();
+                let sym = *sym;
                 if let Some(v) = ev.lookup_var_for_eval(sym)? {
                     let v = v.read();
                     v.used(ev, &sym)?;
@@ -335,7 +335,7 @@ fn parse_dollar(loc: &mut Loc, s: Bytes, end_paren: bool) -> Result<(usize, Arc<
             if let Value::Literal(_, lit) = &*vname {
                 let sym = intern(lit.clone());
                 if FLAGS.enable_kati_warnings {
-                    if let Some(found) = sym.to_string().find(&[' ', '(', '{']) {
+                    if let Some(found) = sym.to_string().find([' ', '(', '{']) {
                         kati_warn_loc!(
                             Some(&start_loc),
                             "*warning*: variable lookup with '{}': {}",
@@ -358,8 +358,8 @@ fn parse_dollar(loc: &mut Loc, s: Bytes, end_paren: bool) -> Result<(usize, Arc<
                         idx,
                         Arc::new(Value::Func {
                             loc: start_loc,
-                            fi: fi,
-                            args: args,
+                            fi,
+                            args,
                         }),
                     ));
                 } else {
@@ -421,8 +421,8 @@ fn parse_dollar(loc: &mut Loc, s: Bytes, end_paren: bool) -> Result<(usize, Arc<
                 Arc::new(Value::VarSubst {
                     loc: start_loc,
                     name: vname,
-                    pat: pat,
-                    subst: subst,
+                    pat,
+                    subst,
                 }),
             ));
         }

--- a/src-rs/fileutil.rs
+++ b/src-rs/fileutil.rs
@@ -152,8 +152,8 @@ fn libc_glob(pattern: &[u8]) -> Result<Vec<Bytes>, std::io::Error> {
         // We can't guarantee that these came from the same allocated
         // object, but this is also only temporary, and will not be
         // used past the globfree which will deallocate any memory.
-        let paths = unsafe { slice::from_raw_parts(gl.gl_pathv, gl.gl_pathc as usize) };
-        ret.reserve_exact(gl.gl_pathc as usize);
+        let paths = unsafe { slice::from_raw_parts(gl.gl_pathv, gl.gl_pathc) };
+        ret.reserve_exact(gl.gl_pathc);
         for ptr in paths {
             if !ptr.is_null() {
                 // SAFETY: This is a non-null pointer, and we assume

--- a/src-rs/fileutil.rs
+++ b/src-rs/fileutil.rs
@@ -109,10 +109,12 @@ pub fn run_command(
     Ok((res, output))
 }
 
-pub static GLOB_CACHE: LazyLock<Mutex<HashMap<Bytes, Arc<Result<Vec<Bytes>, std::io::Error>>>>> =
+pub type GlobResults = Arc<Result<Vec<Bytes>, std::io::Error>>;
+
+pub static GLOB_CACHE: LazyLock<Mutex<HashMap<Bytes, GlobResults>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
-pub fn glob(pat: Bytes) -> Arc<Result<Vec<Bytes>, std::io::Error>> {
+pub fn glob(pat: Bytes) -> GlobResults {
     let mut cache = GLOB_CACHE.lock();
     if let Some(entry) = cache.get(&pat) {
         return entry.clone();

--- a/src-rs/find.rs
+++ b/src-rs/find.rs
@@ -227,7 +227,7 @@ impl DirentNode {
                     return Some(self.clone());
                 }
                 if d == b".." {
-                    return parent.clone().and_then(|p| p.upgrade());
+                    return parent.clone()?.upgrade();
                 }
 
                 let idx = memchr(b'/', d);
@@ -240,9 +240,7 @@ impl DirentNode {
                     return self.find_dir(rest);
                 }
                 if p == b".." {
-                    let Some(parent) = parent.clone().and_then(|p| p.upgrade()) else {
-                        return None;
-                    };
+                    let parent = parent.clone()?.upgrade()?;
                     return parent.find_dir(rest);
                 }
 
@@ -695,7 +693,7 @@ struct FindCommandParser {
     unget_tok: Option<Bytes>,
 }
 
-impl<'a> FindCommandParser {
+impl FindCommandParser {
     fn new(cmd: &Bytes) -> Self {
         FindCommandParser {
             cmd: cmd.clone(),

--- a/src-rs/flags.rs
+++ b/src-rs/flags.rs
@@ -277,14 +277,12 @@ impl Flags {
                         flags.memory_profile_path = Some(arg)
                     } else if arg.as_bytes().starts_with(b"-") {
                         panic!("Unknown flag: {}", arg.to_string_lossy());
+                    } else if arg.as_bytes().contains(&b'=') {
+                        flags.cl_vars.push(Bytes::from(arg.as_bytes().to_vec()));
                     } else {
-                        if arg.as_bytes().contains(&b'=') {
-                            flags.cl_vars.push(Bytes::from(arg.as_bytes().to_vec()));
-                        } else {
-                            should_propagate = false;
-                            let arg = Bytes::from(arg.as_bytes().to_vec());
-                            flags.targets.push(intern(arg));
-                        }
+                        should_propagate = false;
+                        let arg = Bytes::from(arg.as_bytes().to_vec());
+                        flags.targets.push(intern(arg));
                     }
                 }
             }

--- a/src-rs/flags.rs
+++ b/src-rs/flags.rs
@@ -120,7 +120,7 @@ fn parse_command_line_option_with_arg(
 }
 
 impl Flags {
-    pub fn from_args(args: Vec<OsString>) -> Flags {
+    fn from_args(args: Vec<OsString>) -> Flags {
         let mut iter = args.into_iter();
         let mut flags = Flags::default();
         flags.subkati_args.push(iter.next().unwrap());

--- a/src-rs/func.rs
+++ b/src-rs/func.rs
@@ -564,7 +564,7 @@ fn shell_func_impl(
         }
     }
 
-    collect_stats_with_slow_report!("func shell time", OsString::from_vec(cmd.to_vec()));
+    collect_stats_with_slow_report!("func shell time", OsStr::from_bytes(cmd));
     let (status, output) = run_command(shell, shellflag, cmd, RedirectStderr::None)?;
     let output = Bytes::from(format_for_command_substitution(output));
 
@@ -1143,8 +1143,7 @@ fn profile_makefile_func(
     for arg in args {
         let files = arg.eval_to_buf(ev)?;
         for file in word_scanner(&files) {
-            ev.profiled_files
-                .push(String::from_utf8_lossy(file).into_owned());
+            ev.profiled_files.push(OsString::from_vec(file.to_vec()));
         }
     }
     Ok(())

--- a/src-rs/func.rs
+++ b/src-rs/func.rs
@@ -49,10 +49,12 @@ use crate::{
     warn_loc,
 };
 
+type MakeFuncImpl = fn(&[Arc<Value>], &mut Evaluator, &mut dyn BufMut) -> Result<()>;
+
 #[derive(PartialEq)]
 pub struct FuncInfo {
     pub name: &'static [u8],
-    pub func: fn(&[Arc<Value>], &mut Evaluator, &mut dyn BufMut) -> Result<()>,
+    pub func: MakeFuncImpl,
     pub arity: i16,
     pub min_arity: i16,
     // For all parameters.
@@ -1289,11 +1291,7 @@ fn debug_func(args: &[Arc<Value>], ev: &mut Evaluator, _out: &mut dyn BufMut) ->
     Ok(())
 }
 
-const fn func(
-    name: &'static [u8],
-    f: fn(&[Arc<Value>], &mut Evaluator, &mut dyn BufMut) -> Result<()>,
-    arity: i16,
-) -> FuncInfo {
+const fn func(name: &'static [u8], f: MakeFuncImpl, arity: i16) -> FuncInfo {
     FuncInfo {
         name,
         func: f,

--- a/src-rs/func.rs
+++ b/src-rs/func.rs
@@ -238,7 +238,7 @@ fn sort_func(args: &[Arc<Value>], ev: &mut Evaluator, out: &mut dyn BufMut) -> R
 
 fn get_numeric_value_for_func(buf: &[u8]) -> Result<usize> {
     let s = std::str::from_utf8(trim_left_space(buf))?;
-    Ok(usize::from_str_radix(&s, 10)?)
+    Ok(usize::from_str_radix(s, 10)?)
 }
 
 fn word_func(args: &[Arc<Value>], ev: &mut Evaluator, out: &mut dyn BufMut) -> Result<()> {
@@ -666,12 +666,12 @@ fn shell_func(args: &[Arc<Value>], ev: &mut Evaluator, out: &mut dyn BufMut) -> 
     if should_store_command_result(&cmd) {
         COMMAND_RESULTS.lock().push(CommandResult {
             op: CommandOp::Shell,
-            shell: shell,
+            shell,
             shellflag: Bytes::from_static(shellflag),
-            cmd: cmd,
+            cmd,
             find: fc,
             result: output,
-            loc: loc,
+            loc,
         })
     }
     set_shell_status_var(exit_code);
@@ -713,13 +713,11 @@ fn call_func(args: &[Arc<Value>], ev: &mut Evaluator, out: &mut dyn BufMut) -> R
     if let Some(func) = &func {
         let func = func.read();
         func.used(ev, &func_sym)?;
-    } else {
-        if FLAGS.enable_kati_warnings {
-            kati_warn_loc!(
-                ev.loc.as_ref(),
-                "*warning*: undefined user function: {func_sym}"
-            );
-        }
+    } else if FLAGS.enable_kati_warnings {
+        kati_warn_loc!(
+            ev.loc.as_ref(),
+            "*warning*: undefined user function: {func_sym}"
+        );
     }
     let mut av = Vec::with_capacity(args.len() - 1);
     for arg in &args[1..] {
@@ -977,7 +975,7 @@ fn file_func_impl(
         error_loc!(
             ev.loc.as_ref(),
             "*** Invalid file operation: {}.  Stop.",
-            String::from_utf8_lossy(&filename)
+            String::from_utf8_lossy(filename)
         );
     }
     Ok(())
@@ -1143,7 +1141,7 @@ fn profile_makefile_func(
         let files = arg.eval_to_buf(ev)?;
         for file in word_scanner(&files) {
             ev.profiled_files
-                .push(String::from_utf8_lossy(&file).into_owned());
+                .push(String::from_utf8_lossy(file).into_owned());
         }
     }
     Ok(())
@@ -1163,7 +1161,7 @@ fn variable_location_func(
             .peek_var(sym)
             .and_then(|v| v.read().loc().clone())
             .unwrap_or_default();
-        ww.write(&l.to_string().as_bytes());
+        ww.write(l.to_string().as_bytes());
     }
     Ok(())
 }
@@ -1231,7 +1229,7 @@ fn visibility_prefix_func(
             error_loc!(
                 ev.loc.as_ref(),
                 "Visibility prefix {} is not normalized. Normalized prefix: {}",
-                String::from_utf8_lossy(&prefix),
+                String::from_utf8_lossy(prefix),
                 String::from_utf8_lossy(&normalized_prefix)
             );
         }

--- a/src-rs/func.rs
+++ b/src-rs/func.rs
@@ -238,7 +238,7 @@ fn sort_func(args: &[Arc<Value>], ev: &mut Evaluator, out: &mut dyn BufMut) -> R
 
 fn get_numeric_value_for_func(buf: &[u8]) -> Result<usize> {
     let s = std::str::from_utf8(trim_left_space(buf))?;
-    Ok(usize::from_str_radix(s, 10)?)
+    Ok(s.parse::<usize>()?)
 }
 
 fn word_func(args: &[Arc<Value>], ev: &mut Evaluator, out: &mut dyn BufMut) -> Result<()> {

--- a/src-rs/io.rs
+++ b/src-rs/io.rs
@@ -51,8 +51,7 @@ pub fn dump_string(out: &mut impl Write, s: &[u8]) -> Result<()> {
 
 pub fn load_string(f: &mut impl std::io::Read) -> Option<OsString> {
     let len = load_usize(f)?;
-    let mut v = Vec::new();
-    v.resize(len, 0);
+    let mut v = vec![0; len];
     f.read_exact(&mut v[..]).ok()?;
     Some(OsString::from_vec(v))
 }
@@ -113,7 +112,7 @@ mod tests {
     fn test_empty_string() {
         let s = OsString::new();
         let mut buf = Vec::new();
-        dump_string(&mut buf, &s.as_bytes()).unwrap();
+        dump_string(&mut buf, s.as_bytes()).unwrap();
         let mut buf = &buf[..];
         assert_eq!(load_string(&mut buf), Some(s));
     }

--- a/src-rs/lib.rs
+++ b/src-rs/lib.rs
@@ -51,7 +51,7 @@ macro_rules! log {
 #[macro_export]
 macro_rules! log_stat {
     ($fmt:expr $(, $($arg:tt)*)?) => {
-        if crate::flags::FLAGS.enable_stat_logs {
+        if $crate::flags::FLAGS.enable_stat_logs {
             eprintln!("*kati*: {}", format!($fmt, $($($arg)*)?))
         }
     };
@@ -67,7 +67,7 @@ macro_rules! warn {
 #[macro_export]
 macro_rules! kati_warn {
     ($fmt:expr $(, $($arg:tt)*)?) => {
-        if crate::flags::FLAGS.enable_kati_warnings {
+        if $crate::flags::FLAGS.enable_kati_warnings {
             eprintln!($fmt, $($($arg)*)?)
         }
     };
@@ -83,15 +83,15 @@ macro_rules! error {
 #[macro_export]
 macro_rules! warn_loc {
     ($loc:expr, $fmt:expr $(, $($arg:tt)*)?) => {
-        crate::color_warn_log($loc, format!($fmt, $($($arg)*)?))
+        $crate::color_warn_log($loc, format!($fmt, $($($arg)*)?))
     };
 }
 
 #[macro_export]
 macro_rules! kati_warn_loc {
     ($loc:expr, $fmt:expr $(, $($arg:tt)*)?) => {
-        if crate::flags::FLAGS.enable_kati_warnings {
-            crate::color_warn_log($loc, format!($fmt, $($($arg)*)?))
+        if $crate::flags::FLAGS.enable_kati_warnings {
+            $crate::color_warn_log($loc, format!($fmt, $($($arg)*)?))
         }
     };
 }
@@ -99,7 +99,7 @@ macro_rules! kati_warn_loc {
 #[macro_export]
 macro_rules! error_loc {
     ($loc:expr, $fmt:expr $(, $($arg:tt)*)?) => {
-        return Err(crate::color_error_log($loc, format!($fmt, $($($arg)*)?)))
+        return Err($crate::color_error_log($loc, format!($fmt, $($($arg)*)?)))
     };
 }
 
@@ -116,9 +116,9 @@ fn color_error_log(loc: Option<&crate::loc::Loc>, msg: String) -> anyhow::Error 
     if crate::flags::FLAGS.color_warnings {
         let filtered = trim_prefix_str(&msg, "*** ");
 
-        return anyhow::format_err!("{BOLD}{loc}: {RED}error: {RESET}{BOLD}{filtered}{RESET}");
+        anyhow::format_err!("{BOLD}{loc}: {RED}error: {RESET}{BOLD}{filtered}{RESET}")
     } else {
-        return anyhow::format_err!("{loc}: {msg}");
+        anyhow::format_err!("{loc}: {msg}")
     }
 }
 

--- a/src-rs/lib.rs
+++ b/src-rs/lib.rs
@@ -14,6 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// These are the lints enabled by default in Android
+// #![deny(missing_docs)]
+#![deny(warnings)]
+#![deny(unsafe_op_in_unsafe_fn)]
+#![deny(clippy::undocumented_unsafe_blocks)]
+
 use strutil::trim_prefix_str;
 
 pub mod command;

--- a/src-rs/lib.rs
+++ b/src-rs/lib.rs
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// TODO: Add docs
+#![allow(missing_docs)]
 // These are the lints enabled by default in Android
 // #![deny(missing_docs)]
 #![deny(warnings)]

--- a/src-rs/lib.rs
+++ b/src-rs/lib.rs
@@ -14,6 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// TODO: Fix this
+#![allow(clippy::type_complexity)]
+
 use strutil::trim_prefix_str;
 
 pub mod command;

--- a/src-rs/lib.rs
+++ b/src-rs/lib.rs
@@ -14,9 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// TODO: Fix this
-#![allow(clippy::type_complexity)]
-
 use strutil::trim_prefix_str;
 
 pub mod command;

--- a/src-rs/main.rs
+++ b/src-rs/main.rs
@@ -44,7 +44,7 @@ use kati::flags::FLAGS;
 use kati::symtab::{Symbol, intern, join_symbols};
 use kati::timeutil::ScopedTimeReporter;
 
-fn read_bootstrap_makefile(targets: &Vec<Symbol>) -> Result<Arc<Mutex<Vec<Stmt>>>> {
+fn read_bootstrap_makefile(targets: &[Symbol]) -> Result<Arc<Mutex<Vec<Stmt>>>> {
     let mut bootstrap = BytesMut::new();
     bootstrap.put_slice(b"CC?=cc\n");
     if cfg!(target_os = "macos") {
@@ -94,7 +94,7 @@ fn read_bootstrap_makefile(targets: &Vec<Symbol>) -> Result<Arc<Mutex<Vec<Stmt>>
     )
 }
 
-fn run(targets: &Vec<Symbol>, cl_vars: &Vec<Bytes>, orig_args: OsString) -> Result<i32> {
+fn run(targets: &[Symbol], cl_vars: &Vec<Bytes>, orig_args: OsString) -> Result<i32> {
     let start_time = std::time::SystemTime::now();
 
     if FLAGS.generate_ninja && (FLAGS.regen || FLAGS.dump_kati_stamp) {
@@ -214,7 +214,7 @@ fn run(targets: &Vec<Symbol>, cl_vars: &Vec<Bytes>, orig_args: OsString) -> Resu
             Loc::default(),
         );
         let _tr = ScopedTimeReporter::new("make dep time");
-        nodes = make_dep(&mut ev, targets.clone())?;
+        nodes = make_dep(&mut ev, targets.to_owned())?;
     }
 
     if FLAGS.is_syntax_check_only {

--- a/src-rs/main.rs
+++ b/src-rs/main.rs
@@ -14,6 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// TODO: Add docs
+#![allow(missing_docs)]
 // These are the lints enabled by default in Android
 // #![deny(missing_docs)]
 #![deny(warnings)]

--- a/src-rs/main.rs
+++ b/src-rs/main.rs
@@ -292,7 +292,7 @@ fn handle_realpath(args: Vec<String>) {
     for arg in args {
         if let Ok(path) = std::fs::canonicalize(&arg) {
             let _ = stdout().write_all(path.as_os_str().as_bytes());
-            println!("");
+            println!();
         }
     }
 }

--- a/src-rs/main.rs
+++ b/src-rs/main.rs
@@ -14,6 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// These are the lints enabled by default in Android
+// #![deny(missing_docs)]
+#![deny(warnings)]
+#![deny(unsafe_op_in_unsafe_fn)]
+#![deny(clippy::undocumented_unsafe_blocks)]
+
 use std::ffi::{OsStr, OsString};
 use std::io::{Write, stdout};
 use std::os::unix::ffi::OsStrExt;

--- a/src-rs/ninja.rs
+++ b/src-rs/ninja.rs
@@ -70,9 +70,9 @@ fn find_command_line_flag_with_arg(cmd: &[u8], name: &[u8]) -> Option<Vec<u8>> {
 }
 
 fn get_depfile_from_command_impl(cmd: &mut BytesMut) -> Result<Option<Vec<u8>>> {
-    if (find_command_line_flag(&cmd, b" -MD").is_none()
-        && find_command_line_flag(&cmd, b" -MMD").is_none())
-        || find_command_line_flag(&cmd, b" -c").is_none()
+    if (find_command_line_flag(cmd, b" -MD").is_none()
+        && find_command_line_flag(cmd, b" -MMD").is_none())
+        || find_command_line_flag(cmd, b" -c").is_none()
     {
         return Ok(None);
     }
@@ -432,7 +432,7 @@ impl<'a> NinjaGenerator<'a> {
 
     fn get_depfile(&mut self, node: &DepNode, cmd_buf: &mut BytesMut) -> Result<Option<Bytes>> {
         if let Some(depfile_var) = node.depfile_var.clone() {
-            let depfile = depfile_var.read().eval_to_buf(&mut self.ce.ev)?;
+            let depfile = depfile_var.read().eval_to_buf(self.ce.ev)?;
             return Ok(Some(depfile));
         }
         if !FLAGS.detect_depfiles {
@@ -578,7 +578,7 @@ impl<'a> NinjaGenerator<'a> {
             }
         }
 
-        writeln!(out, "")?;
+        writeln!(out)?;
 
         let pool = if let Some(ninja_pool_var) = &node.ninja_pool_var {
             Some(ninja_pool_var.read().eval_to_buf(self.ce.ev)?)
@@ -608,7 +608,7 @@ impl<'a> NinjaGenerator<'a> {
             if !tags.is_empty() {
                 write!(out, " tags = ")?;
                 out.write_all(&tags)?;
-                writeln!(out, "")?;
+                writeln!(out)?;
             }
         }
         if node.is_default_target {
@@ -635,7 +635,7 @@ impl<'a> NinjaGenerator<'a> {
                 out.write_all(value.as_bytes())?;
                 out.write_all(b"\n")?;
             }
-            writeln!(out, "")?;
+            writeln!(out)?;
         }
 
         if !FLAGS.no_ninja_prelude {
@@ -768,9 +768,9 @@ impl<'a> NinjaGenerator<'a> {
                 .collect();
             dump_usize(&mut out, globs.len())?;
             for (key, files) in globs.iter() {
-                dump_string(&mut out, &key)?;
+                dump_string(&mut out, key)?;
                 let Ok(files) = files.as_ref() else { continue };
-                dump_vec_string(&mut out, &files)?;
+                dump_vec_string(&mut out, files)?;
             }
 
             let crs = crate::func::COMMAND_RESULTS.lock();
@@ -786,7 +786,7 @@ impl<'a> NinjaGenerator<'a> {
 
                 if cr.op == CommandOp::Find {
                     let fc = cr.find.as_ref().unwrap();
-                    let chdir = fc.chdir.clone().unwrap_or_else(|| Bytes::new());
+                    let chdir = fc.chdir.clone().unwrap_or_else(Bytes::new);
                     let mut missing_dirs = Vec::new();
                     for fd in &fc.finddirs {
                         let d = concat_dir(&chdir, fd);

--- a/src-rs/ninja.rs
+++ b/src-rs/ninja.rs
@@ -755,7 +755,7 @@ impl<'a> NinjaGenerator<'a> {
             }
 
             let globs = crate::fileutil::GLOB_CACHE.lock();
-            let globs: Vec<(&Bytes, &Arc<Result<Vec<Bytes>, std::io::Error>>)> = globs
+            let globs: Vec<(&Bytes, &crate::fileutil::GlobResults)> = globs
                 .iter()
                 .filter_map(|(key, files)| {
                     if files.is_err() {

--- a/src-rs/ninja.rs
+++ b/src-rs/ninja.rs
@@ -54,9 +54,7 @@ fn find_command_line_flag(cmd: &[u8], name: &[u8]) -> Option<usize> {
 }
 
 fn find_command_line_flag_with_arg(cmd: &[u8], name: &[u8]) -> Option<Vec<u8>> {
-    let Some(idx) = find_command_line_flag(cmd, name) else {
-        return None;
-    };
+    let idx = find_command_line_flag(cmd, name)?;
 
     let mut val = trim_left_space(&cmd[idx + name.len()..]);
     while let Some(idx) = memmem::find(val, name) {

--- a/src-rs/parser.rs
+++ b/src-rs/parser.rs
@@ -191,7 +191,9 @@ impl Parser {
             if self.is_in_export() {
                 return Ok(());
             }
-            sep.as_mut().map(|sep| *sep += orig_line.len() - line.len());
+            if let Some(sep) = sep.as_mut() {
+                *sep += orig_line.len() - line.len()
+            }
             line = orig_line.clone();
         }
 

--- a/src-rs/parser.rs
+++ b/src-rs/parser.rs
@@ -168,7 +168,7 @@ impl Parser {
     }
 
     fn parse_rule_or_assign(&mut self, line: Bytes) -> Result<()> {
-        let Some(sep) = find_outside_paren(line.as_ref(), &[b':', b'=', b';']) else {
+        let Some(sep) = find_outside_paren(line.as_ref(), b":=;") else {
             return self.parse_rule(line, None);
         };
         let s = &line[sep..];
@@ -214,7 +214,7 @@ impl Parser {
 
         let sep_plus_one = sep.map(|sep| sep + 1).unwrap_or(0);
 
-        let found = find_outside_paren(&line[sep_plus_one..], &[b'=', b';']);
+        let found = find_outside_paren(&line[sep_plus_one..], b"=;");
         let mut mutable_loc = self.loc.clone();
         if let Some(mut found) = found {
             found += sep_plus_one;
@@ -336,7 +336,7 @@ impl Parser {
         }
 
         let assign_loc = Loc {
-            filename: self.loc.filename.clone(),
+            filename: self.loc.filename,
             line: self.define_start_line,
         };
         let mut mutable_loc = assign_loc.clone();
@@ -521,7 +521,7 @@ impl Parser {
     }
 
     fn is_in_export(&self) -> bool {
-        return self.current_directive.map_or(false, |d| d.export);
+        self.current_directive.is_some_and(|d| d.export)
     }
 
     fn create_export(&mut self, line: &Bytes, is_export: bool) -> Result<()> {
@@ -570,7 +570,7 @@ impl Parser {
     }
 
     fn remove_comment(line: &[u8]) -> &[u8] {
-        if let Some(i) = find_outside_paren(line, &[b'#']) {
+        if let Some(i) = find_outside_paren(line, b"#") {
             return &line[..i];
         }
         line
@@ -592,7 +592,7 @@ impl Parser {
         let rest = line.slice_ref(trim_right_space(Parser::remove_comment(trim_left_space(
             &line[directive.len()..],
         ))));
-        match directive.as_ref() {
+        match directive {
             b"include" | b"-include" | b"sinclude" => self.parse_include(rest, directive)?,
             b"define" => self.parse_define(rest)?,
             b"ifdef" | b"ifndef" => self.parse_ifdef(rest, directive)?,
@@ -612,7 +612,7 @@ impl Parser {
         let rest = line.slice_ref(trim_right_space(Parser::remove_comment(trim_left_space(
             &line[directive.len()..],
         ))));
-        match directive.as_ref() {
+        match directive {
             b"ifdef" | b"ifndef" => self.parse_ifdef(rest, directive)?,
             b"ifeq" | b"ifneq" => self.parse_ifeq(rest, directive)?,
             _ => return Ok(false),
@@ -625,7 +625,7 @@ impl Parser {
         let rest = line.slice_ref(trim_right_space(Parser::remove_comment(trim_left_space(
             &line[directive.len()..],
         ))));
-        match directive.as_ref() {
+        match directive {
             b"define" => self.parse_define(rest)?,
             b"override" => self.parse_override(rest)?,
             b"export" => self.parse_export(rest)?,

--- a/src-rs/regen.rs
+++ b/src-rs/regen.rs
@@ -412,7 +412,7 @@ impl StampChecker {
             }
         }
 
-        collect_stats_with_slow_report!("shell time (regen)", sr.cmd.clone());
+        collect_stats_with_slow_report!("shell time (regen)", &sr.cmd);
         let (_status, output) = run_command(
             sr.shell.as_bytes(),
             sr.shellflag.as_bytes(),

--- a/src-rs/regen_dump.rs
+++ b/src-rs/regen_dump.rs
@@ -150,7 +150,7 @@ fn inner(
                 println!("  shell flagss: {shellflag:?}");
                 println!("  loc: {file:?}:{line}");
                 println!("  cmd: {cmd:?}");
-                if result.len() > 0 && result.len() < 500 && !result.as_bytes().contains(&b'\n') {
+                if !result.is_empty() && result.len() < 500 && !result.as_bytes().contains(&b'\n') {
                     println!("  output: {result:?}");
                 } else {
                     println!("  output: <{} bytes>", result.len());
@@ -167,7 +167,7 @@ fn inner(
                 for d in read_dirs {
                     println!("    {d:?}");
                 }
-                println!("");
+                println!();
             }
         } else if dump_cmds {
             match op {
@@ -184,7 +184,7 @@ fn inner(
             }
             println!("  loc: {file:?}:{line}");
             println!("  cmd: {cmd:?}");
-            if result.len() > 0 && result.len() < 500 && !result.as_bytes().contains(&b'\n') {
+            if !result.is_empty() && result.len() < 500 && !result.as_bytes().contains(&b'\n') {
                 println!("  output: {result:?}");
             } else {
                 println!("  output: <{} bytes>", result.len());

--- a/src-rs/rule.rs
+++ b/src-rs/rule.rs
@@ -53,7 +53,7 @@ impl Rule {
             is_double_colon,
             is_suffix_rule: false,
             cmds: Vec::new(),
-            loc: loc,
+            loc,
             cmd_loc: None,
         }
     }

--- a/src-rs/stats.rs
+++ b/src-rs/stats.rs
@@ -14,11 +14,14 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+//! `kati::stats` implements stats collection and reporting about regions of
+//! execution.
+
 use crate::{flags::FLAGS, symtab::symbol_count};
 use parking_lot::Mutex;
 use std::{
     collections::{HashMap, HashSet},
-    ffi::OsString,
+    ffi::{OsStr, OsString},
     fmt::Display,
     sync::Arc,
     time::{Duration, Instant},
@@ -32,15 +35,19 @@ struct StatsDetails {
     elapsed: Duration,
 }
 
+/// `Stats` represents a single collection site.
 pub struct Stats {
     name: String,
     count: Mutex<i64>,
     elapsed: Mutex<Duration>,
-    detailed: Mutex<HashMap<String, StatsDetails>>,
-    interesting: Mutex<HashSet<String>>,
+    detailed: Mutex<HashMap<OsString, StatsDetails>>,
+    interesting: Mutex<HashSet<OsString>>,
 }
 
 impl Stats {
+    /// Create a new `Stats` instance. Normally you would use [`collect_stats!`]
+    /// or [`collect_stats_with_slow_report!`] to call this.
+    #[doc(hidden)]
     pub fn new(name: &str) -> Arc<Self> {
         let stats = Arc::new(Self {
             name: name.to_string(),
@@ -94,12 +101,26 @@ impl Stats {
                 "*kati*: {:>6.3} / {:>max_cnt_len$} {}",
                 details.elapsed.as_secs_f64(),
                 details.count,
-                name
+                name.to_string_lossy()
             );
         }
     }
 
-    pub fn start(&self) -> Instant {
+    /// The implementation behind [`collect_stats!`]
+    #[doc(hidden)]
+    #[must_use]
+    pub fn start_scope(self: &Arc<Self>) -> impl Drop {
+        ScopedStatsRecorder::new(self)
+    }
+
+    /// The implementation behind [`collect_stats_with_slow_report!`]
+    #[doc(hidden)]
+    #[must_use]
+    pub fn start_scope_with_slow_report(self: &Arc<Self>, msg: &OsStr) -> impl Drop {
+        ScopedStatsRecorderWithSlowReport::new(self, msg)
+    }
+
+    fn start(&self) -> Instant {
         let start = std::time::Instant::now();
         *self.count.lock() += 1;
         start
@@ -111,18 +132,23 @@ impl Stats {
         elapsed
     }
 
-    fn end_with_msg(&self, start: Instant, msg: &str) -> Duration {
+    fn end_with_msg(&self, start: Instant, msg: &OsStr) -> Duration {
         let elapsed = start.elapsed();
         *self.elapsed.lock() += elapsed;
         let mut detailed = self.detailed.lock();
-        let details = detailed.entry(msg.to_string()).or_default();
-        details.count += 1;
-        details.elapsed += elapsed;
+        if let Some(details) = detailed.get_mut(msg) {
+            details.count += 1;
+            details.elapsed += elapsed;
+        } else {
+            detailed.insert(msg.to_owned(), StatsDetails { count: 1, elapsed });
+        }
         elapsed
     }
 
-    pub fn mark_interesting(&self, name: &str) {
-        self.interesting.lock().insert(name.to_string());
+    /// Mark the specific execution as interesting. It will be logged even if
+    /// it isn't in the top 10 executions.
+    pub fn mark_interesting(&self, name: OsString) {
+        self.interesting.lock().insert(name);
     }
 }
 
@@ -149,88 +175,90 @@ impl Display for Stats {
     }
 }
 
-pub struct ScopedStatsRecorder {
-    st: Arc<Stats>,
+struct ScopedStatsRecorder<'a> {
+    st: &'a Stats,
     start: Instant,
 }
 
-impl ScopedStatsRecorder {
-    pub fn new(st: &Arc<Stats>) -> Self {
+impl<'a> ScopedStatsRecorder<'a> {
+    fn new(st: &'a Stats) -> Self {
         let start = st.start();
-        Self {
-            st: st.clone(),
-            start,
-        }
+        Self { st, start }
     }
 }
 
-impl Drop for ScopedStatsRecorder {
+impl Drop for ScopedStatsRecorder<'_> {
     fn drop(&mut self) {
         self.st.end(self.start);
     }
 }
 
+/// Define and collect statistics about this block of code.
+///
+/// We'll record both the count and duration of these blocks, and report them
+/// when [`report_all_stats`] is called.
 #[macro_export]
 macro_rules! collect_stats {
     ($name:literal) => {
         static STATS: std::sync::LazyLock<std::sync::Arc<$crate::stats::Stats>> =
             std::sync::LazyLock::new(|| $crate::stats::Stats::new($name));
         let _ssr = if $crate::flags::FLAGS.enable_stat_logs {
-            Some($crate::stats::ScopedStatsRecorder::new(&STATS))
+            Some(STATS.start_scope())
         } else {
             None
         };
     };
 }
 
-pub struct ScopedStatsRecorderWithSlowReport {
-    st: Arc<Stats>,
-    msg: OsString,
+struct ScopedStatsRecorderWithSlowReport<'a, 'b> {
+    st: &'a Stats,
+    msg: &'b OsStr,
     start: Instant,
 }
 
-impl ScopedStatsRecorderWithSlowReport {
-    pub fn new(st: &Arc<Stats>, start: Instant, msg: OsString) -> Self {
-        Self {
-            st: st.clone(),
-            msg,
-            start,
-        }
+impl<'a, 'b> ScopedStatsRecorderWithSlowReport<'a, 'b> {
+    fn new(st: &'a Stats, msg: &'b OsStr) -> Self {
+        let start = st.start();
+        Self { st, msg, start }
     }
 }
 
-impl Drop for ScopedStatsRecorderWithSlowReport {
+impl Drop for ScopedStatsRecorderWithSlowReport<'_, '_> {
     fn drop(&mut self) {
-        let msg = self.msg.to_string_lossy();
-        let dur = self.st.end_with_msg(self.start, &msg);
+        let dur = self.st.end_with_msg(self.start, self.msg);
         if dur > Duration::from_secs(3) {
             eprintln!(
                 "*kati*: slow {} ({}): {}",
                 self.st.name,
                 dur.as_secs_f64(),
-                msg
+                self.msg.to_string_lossy()
             )
         }
     }
 }
 
+/// Define and collect statistics about this block of code, with specific
+/// executions identified by the `msg`.
+///
+/// We'll record both the count and duration of these blocks, and report them
+/// when [`report_all_stats`] is called. In addition, the top ten specific
+/// instances will have their duration and counts reported as well.
+///
+/// Any executions over 3 seconds will be logged as they happen.
 #[macro_export]
 macro_rules! collect_stats_with_slow_report {
     ($name:literal, $msg:expr) => {
         static STATS: std::sync::LazyLock<std::sync::Arc<$crate::stats::Stats>> =
             std::sync::LazyLock::new(|| $crate::stats::Stats::new($name));
         let _ssr = if $crate::flags::FLAGS.enable_stat_logs {
-            let start = STATS.start();
-            let msg = $msg;
-            Some($crate::stats::ScopedStatsRecorderWithSlowReport::new(
-                &STATS, start, msg,
-            ))
+            Some(STATS.start_scope_with_slow_report($msg))
         } else {
             None
         };
     };
 }
 
+/// Report all the statistics to stderr, if `--enable_stat_log` is enabled.
 pub fn report_all_stats() {
     let all_stats = std::mem::take(&mut *ALL_STATS.lock());
     if FLAGS.enable_stat_logs {

--- a/src-rs/stmt.rs
+++ b/src-rs/stmt.rs
@@ -103,11 +103,11 @@ impl Debug for RuleStmt {
 impl RuleStmt {
     pub fn new(loc: Loc, lhs: Arc<Value>, sep: RuleSep, rhs: Option<Arc<Value>>) -> Arc<RuleStmt> {
         Arc::new(RuleStmt {
-            loc: loc,
+            loc,
             orig: Bytes::new(),
-            lhs: lhs,
-            sep: sep,
-            rhs: rhs,
+            lhs,
+            sep,
+            rhs,
         })
     }
 }
@@ -166,14 +166,14 @@ impl AssignStmt {
         is_final: bool,
     ) -> Arc<AssignStmt> {
         Arc::new(AssignStmt {
-            loc: loc,
+            loc,
             orig: Bytes::new(),
-            lhs: lhs,
-            rhs: rhs,
+            lhs,
+            rhs,
             orig_rhs,
-            op: op,
-            directive: directive,
-            is_final: is_final,
+            op,
+            directive,
+            is_final,
             lhs_sym_cache: Mutex::new(None),
         })
     }
@@ -188,7 +188,7 @@ impl AssignStmt {
             if cache.is_none() {
                 *cache = Some(intern(v.clone()));
             }
-            return Ok(cache.clone().unwrap());
+            return Ok((*cache).unwrap());
         }
 
         let buf = self.lhs.eval_to_buf(ev)?;
@@ -271,11 +271,11 @@ impl Debug for IfStmt {
 impl IfStmt {
     pub fn new(loc: Loc, op: CondOp, lhs: Arc<Value>, rhs: Option<Arc<Value>>) -> Arc<IfStmt> {
         Arc::new(IfStmt {
-            loc: loc,
+            loc,
             orig: Bytes::new(),
-            op: op,
-            lhs: lhs,
-            rhs: rhs,
+            op,
+            lhs,
+            rhs,
             true_stmts: Arc::new(Mutex::new(Vec::new())),
             false_stmts: Arc::new(Mutex::new(Vec::new())),
         })
@@ -311,10 +311,10 @@ impl Debug for IncludeStmt {
 impl IncludeStmt {
     pub fn new(loc: Loc, expr: Arc<Value>, should_exist: bool) -> Arc<IncludeStmt> {
         Arc::new(IncludeStmt {
-            loc: loc,
+            loc,
             orig: Bytes::new(),
-            expr: expr,
-            should_exist: should_exist,
+            expr,
+            should_exist,
         })
     }
 }
@@ -352,10 +352,10 @@ impl Debug for ExportStmt {
 impl ExportStmt {
     pub fn new(loc: Loc, expr: Arc<Value>, is_export: bool) -> Arc<ExportStmt> {
         Arc::new(ExportStmt {
-            loc: loc,
+            loc,
             orig: Bytes::new(),
-            expr: expr,
-            is_export: is_export,
+            expr,
+            is_export,
         })
     }
 }

--- a/src-rs/strutil.rs
+++ b/src-rs/strutil.rs
@@ -247,9 +247,7 @@ pub fn basename(s: &[u8]) -> &[u8] {
 }
 
 pub fn get_ext(s: &[u8]) -> Option<&[u8]> {
-    let Some(found) = memrchr(b'.', s) else {
-        return None;
-    };
+    let found = memrchr(b'.', s)?;
     Some(&s[found..])
 }
 
@@ -295,9 +293,7 @@ pub fn normalize_path(mut o: &[u8]) -> Bytes {
         };
         o = rest;
 
-        if dir == b"." {
-            continue;
-        } else if dir == b".." && ret.as_ref() == b"/" {
+        if dir == b"." || (dir == b".." && ret.as_ref() == b"/") {
             continue;
         } else if dir == b".." && !ret.is_empty() && ret.as_ref() != b".." && !ret.ends_with(b"/..")
         {

--- a/src-rs/strutil.rs
+++ b/src-rs/strutil.rs
@@ -20,22 +20,22 @@ use memchr::{memchr, memchr2, memmem, memrchr};
 use std::{borrow::Cow, env::current_dir, os::unix::ffi::OsStrExt};
 
 pub fn is_space(c: char) -> bool {
-    ('\t' <= c && c <= '\r') || c == ' '
+    ('\t'..='\r').contains(&c) || c == ' '
 }
 
 pub fn is_space_byte(c: &u8) -> bool {
     let c = *c;
-    (b'\t' <= c && c <= b'\r') || c == b' '
+    (b'\t'..=b'\r').contains(&c) || c == b' '
 }
 
 pub fn skip_until(s: &[u8], pattern: &[u8]) -> usize {
     s.iter()
         .position(|c| pattern.contains(c))
-        .unwrap_or_else(|| s.len())
+        .unwrap_or(s.len())
 }
 
 pub fn skip_until2(s: &[u8], needle1: u8, needle2: u8) -> usize {
-    memchr2(needle1, needle2, s).unwrap_or_else(|| s.len())
+    memchr2(needle1, needle2, s).unwrap_or(s.len())
 }
 
 pub fn word_scanner(s: &[u8]) -> impl Iterator<Item = &[u8]> {
@@ -50,7 +50,7 @@ pub struct WordWriter<'a> {
 impl<'a> WordWriter<'a> {
     pub fn new(out: &'a mut dyn BufMut) -> WordWriter<'a> {
         WordWriter {
-            out: out,
+            out,
             needs_space: false,
         }
     }
@@ -167,7 +167,7 @@ impl Pattern {
             }
             return subst.clone();
         }
-        return s.clone();
+        s.clone()
     }
 
     pub fn append_subst_ref(&self, s: &Bytes, subst: &Bytes) -> Bytes {
@@ -352,7 +352,7 @@ pub fn find_outside_paren(s: &[u8], pattern: &[u8]) -> Option<usize> {
             b'(' => paren_stack.push(b')'),
             b'{' => paren_stack.push(b'}'),
             b')' | b'}' => {
-                if paren_stack.last() == Some(&c) {
+                if paren_stack.last() == Some(c) {
                     paren_stack.pop();
                 }
             }
@@ -408,7 +408,7 @@ pub fn find_end_of_line(buf: &Bytes) -> EndOfLine {
     EndOfLine {
         line: buf.slice(..e),
         rest: buf.slice(e..),
-        lf_cnt: lf_cnt,
+        lf_cnt,
     }
 }
 
@@ -425,7 +425,7 @@ pub fn format_for_command_substitution(mut s: Vec<u8>) -> Vec<u8> {
     }
     let mut search = 0;
     while let Some(idx) = memchr(b'\n', &s[search..]) {
-        search = search + idx;
+        search += idx;
         s[search] = b' ';
     }
     s
@@ -455,7 +455,7 @@ pub fn echo_escape(s: &[u8]) -> Bytes {
 }
 
 pub fn escape_shell(s: &Bytes) -> Bytes {
-    let delimiters = &[b'"', b'$', b'\\', b'`'];
+    let delimiters = b"\"$\\`";
     let mut prev = 0;
     let mut i = skip_until(s, delimiters);
     if i == s.len() {
@@ -484,7 +484,7 @@ pub fn is_integer(str: &[u8]) -> bool {
     if str.is_empty() {
         return false;
     }
-    str.iter().all(|c| (*c as char).is_digit(10))
+    str.iter().all(|c| (*c as char).is_ascii_digit())
 }
 
 #[cfg(test)]
@@ -653,60 +653,60 @@ mod test {
 
     #[test]
     fn test_is_integer() {
-        assert_eq!(is_integer(b"0"), true);
-        assert_eq!(is_integer(b"9"), true);
-        assert_eq!(is_integer(b"1234"), true);
-        assert_eq!(is_integer(b""), false);
-        assert_eq!(is_integer(b"a234"), false);
-        assert_eq!(is_integer(b"123a"), false);
-        assert_eq!(is_integer(b"12a4"), false);
+        assert!(is_integer(b"0"));
+        assert!(is_integer(b"9"));
+        assert!(is_integer(b"1234"));
+        assert!(!is_integer(b""));
+        assert!(!is_integer(b"a234"));
+        assert!(!is_integer(b"123a"));
+        assert!(!is_integer(b"12a4"));
     }
 
     #[test]
     fn test_find_outside_paren_simple() {
-        assert_eq!(find_outside_paren(b"abc", &[b'b']), Some(1));
-        assert_eq!(find_outside_paren(b":abc", &[b':']), Some(0));
-        assert_eq!(find_outside_paren(b"abc:", &[b':']), Some(3));
-        assert_eq!(find_outside_paren(b"abc", &[b'd']), None);
-        assert_eq!(find_outside_paren(b"", &[b'a']), None);
+        assert_eq!(find_outside_paren(b"abc", b"b"), Some(1));
+        assert_eq!(find_outside_paren(b":abc", b":"), Some(0));
+        assert_eq!(find_outside_paren(b"abc:", b":"), Some(3));
+        assert_eq!(find_outside_paren(b"abc", b"d"), None);
+        assert_eq!(find_outside_paren(b"", b"a"), None);
         assert_eq!(find_outside_paren(b"abc", &[]), None);
-        assert_eq!(find_outside_paren(b"a=b:c", &[b':', b'=']), Some(1)); // Finds '=' first
-        assert_eq!(find_outside_paren(b"a:b=c", &[b':', b'=']), Some(1)); // Finds ':' first
+        assert_eq!(find_outside_paren(b"a=b:c", b":="), Some(1)); // Finds '=' first
+        assert_eq!(find_outside_paren(b"a:b=c", b":="), Some(1)); // Finds ':' first
     }
 
     #[test]
     fn test_find_outside_paren_parentheses() {
-        assert_eq!(find_outside_paren(b"a(b:c)d", &[b':']), None); // ':' is inside ()
-        assert_eq!(find_outside_paren(b"a{b:c}d", &[b':']), None); // ':' is inside {}
-        assert_eq!(find_outside_paren(b"a(b)c:d", &[b':']), Some(5)); // ':' is outside after ()
-        assert_eq!(find_outside_paren(b"a{b}c:d", &[b':']), Some(5)); // ':' is outside after {}
-        assert_eq!(find_outside_paren(b"a:b(c)d", &[b':']), Some(1)); // ':' is outside before ()
-        assert_eq!(find_outside_paren(b"a((b:c))d", &[b':']), None); // Nested ()
-        assert_eq!(find_outside_paren(b"a{{b:c}}d", &[b':']), None); // Nested {}
-        assert_eq!(find_outside_paren(b"a({b:c})d", &[b':']), None); // Mixed nested {} inside ()
-        assert_eq!(find_outside_paren(b"a{(b:c)}d", &[b':']), None); // Mixed nested () inside {}
-        assert_eq!(find_outside_paren(b"a(b):c", &[b':']), Some(4)); // Immediately after )
-        assert_eq!(find_outside_paren(b"a{b}:c", &[b':']), Some(4)); // Immediately after }
+        assert_eq!(find_outside_paren(b"a(b:c)d", b":"), None); // ':' is inside ()
+        assert_eq!(find_outside_paren(b"a{b:c}d", b":"), None); // ':' is inside {}
+        assert_eq!(find_outside_paren(b"a(b)c:d", b":"), Some(5)); // ':' is outside after ()
+        assert_eq!(find_outside_paren(b"a{b}c:d", b":"), Some(5)); // ':' is outside after {}
+        assert_eq!(find_outside_paren(b"a:b(c)d", b":"), Some(1)); // ':' is outside before ()
+        assert_eq!(find_outside_paren(b"a((b:c))d", b":"), None); // Nested ()
+        assert_eq!(find_outside_paren(b"a{{b:c}}d", b":"), None); // Nested {}
+        assert_eq!(find_outside_paren(b"a({b:c})d", b":"), None); // Mixed nested {} inside ()
+        assert_eq!(find_outside_paren(b"a{(b:c)}d", b":"), None); // Mixed nested () inside {}
+        assert_eq!(find_outside_paren(b"a(b):c", b":"), Some(4)); // Immediately after )
+        assert_eq!(find_outside_paren(b"a{b}:c", b":"), Some(4)); // Immediately after }
         // Mismatched parens - should still find outside ones correctly before mismatch
-        assert_eq!(find_outside_paren(b"a(b:c", &[b':']), None);
-        assert_eq!(find_outside_paren(b"a)b:c", &[b':']), Some(3));
-        assert_eq!(find_outside_paren(b"a{b:c", &[b':']), None);
-        assert_eq!(find_outside_paren(b"a}b:c", &[b':']), Some(3));
+        assert_eq!(find_outside_paren(b"a(b:c", b":"), None);
+        assert_eq!(find_outside_paren(b"a)b:c", b":"), Some(3));
+        assert_eq!(find_outside_paren(b"a{b:c", b":"), None);
+        assert_eq!(find_outside_paren(b"a}b:c", b":"), Some(3));
     }
 
     #[test]
     fn test_find_outside_paren_escapes() {
-        assert_eq!(find_outside_paren(b"a\\:b:c", &[b':']), Some(4)); // Escaped ':' ignored, finds second ':'
-        assert_eq!(find_outside_paren(b"a\\\\:b", &[b':']), Some(3)); // Escaped '\\', finds ':'
+        assert_eq!(find_outside_paren(b"a\\:b:c", b":"), Some(4)); // Escaped ':' ignored, finds second ':'
+        assert_eq!(find_outside_paren(b"a\\\\:b", b":"), Some(3)); // Escaped '\\', finds ':'
         // Test case for escaped newline - find_outside_paren doesn't see the newline itself
         // as it's processed line by line after find_end_of_line.
         // Let's test a scenario where the escape is just before the target.
-        assert_eq!(find_outside_paren(b"abc\\", &[b'c']), Some(2)); // Escaped char at end
-        assert_eq!(find_outside_paren(b"abc\\:", &[b':']), None); // Escaped target char
+        assert_eq!(find_outside_paren(b"abc\\", b"c"), Some(2)); // Escaped char at end
+        assert_eq!(find_outside_paren(b"abc\\:", b":"), None); // Escaped target char
     }
 
     #[test]
     fn test_find_outside_paren_combinations() {
-        assert_eq!(find_outside_paren(b"a(b\\:c):d", &[b':']), Some(7)); // Escaped ':' inside (), find ':' outside
+        assert_eq!(find_outside_paren(b"a(b\\:c):d", b":"), Some(7)); // Escaped ':' inside (), find ':' outside
     }
 }

--- a/src-rs/symtab.rs
+++ b/src-rs/symtab.rs
@@ -106,10 +106,7 @@ impl ScopedGlobalVar {
             symtab.symbol_data.resize(idx + 1, None);
         }
         symtab.symbol_data[idx] = Some(var);
-        Ok(Self {
-            sym: sym,
-            orig: orig,
-        })
+        Ok(Self { sym, orig })
     }
 }
 

--- a/src-rs/timeutil.rs
+++ b/src-rs/timeutil.rs
@@ -26,7 +26,7 @@ impl ScopedTimeReporter {
         let start = std::time::Instant::now();
         Self {
             name: name.to_string(),
-            start: start,
+            start,
         }
     }
 }

--- a/src-rs/var.rs
+++ b/src-rs/var.rs
@@ -138,10 +138,7 @@ impl Variable {
         Ok(())
     }
     pub fn immediate_eval(&self) -> bool {
-        match &self.value {
-            InnerVar::Simple(_) => true,
-            _ => false,
-        }
+        matches!(&self.value, InnerVar::Simple(_))
     }
     pub fn append_var(
         &mut self,
@@ -400,7 +397,7 @@ impl Evaluable for Variable {
                 for (sym, entry) in symbols {
                     if !*all {
                         if let Some(var) = sym.peek_global_var() {
-                            if var.read().is_func(ev) {
+                            if var.read().is_func() {
                                 continue;
                             }
                         }
@@ -411,10 +408,10 @@ impl Evaluable for Variable {
         }
         Ok(())
     }
-    fn is_func(&self, ev: &crate::eval::Evaluator) -> bool {
+    fn is_func(&self) -> bool {
         match &self.value {
             InnerVar::Simple(_) => false,
-            InnerVar::Recursive { v, .. } => v.is_func(ev),
+            InnerVar::Recursive { v, .. } => v.is_func(),
             InnerVar::AutoCommand(_, _) => true,
             InnerVar::ShellStatus => false,
             InnerVar::VariableNames { .. } => false,
@@ -445,9 +442,7 @@ impl Vars {
     }
 
     pub fn lookup(&self, sym: Symbol) -> Option<Var> {
-        let Some(ret) = self.0.lock().get(&sym).cloned() else {
-            return None;
-        };
+        let ret = self.0.lock().get(&sym).cloned()?;
         match ret.read().origin() {
             VarOrigin::Environment | VarOrigin::EnvironmentOverride => {
                 USED_ENV_VARS.lock().insert(sym);

--- a/src/Android.bp
+++ b/src/Android.bp
@@ -77,14 +77,25 @@ cc_binary_host {
 }
 
 cc_test_host {
-    name: "ckati_test",
+    name: "ckati_find_test",
     defaults: ["ckati_defaults"],
-    test_per_src: true,
-    srcs: [
-        "find_test.cc",
-        "ninja_test.cc",
-        "strutil_test.cc",
-    ],
+    srcs: ["find_test.cc"],
+    gtest: false,
+    static_libs: ["libckati"],
+}
+
+cc_test_host {
+    name: "ckati_ninja_test",
+    defaults: ["ckati_defaults"],
+    srcs: ["ninja_test.cc"],
+    gtest: false,
+    static_libs: ["libckati"],
+}
+
+cc_test_host {
+    name: "ckati_strutil_test",
+    defaults: ["ckati_defaults"],
+    srcs: ["strutil_test.cc"],
     gtest: false,
     static_libs: ["libckati"],
 }


### PR DESCRIPTION
Android by default enables clippy and some extra lints for rust compilations. Enable those here as well, except for `missing_docs`, as we have a lot of those to clean up. Then add an Android.bp file so that we can compile both ckati and rkati in the same environment.

I've started cleaning up some interfaces and writing docs with a couple of these commits, but docs are largely going to be incremental with other cleanups going forward.

Also cherrypick [Remove test_per_src from build/kati](https://android.googlesource.com/platform/build/kati/+/74af332b81f7b5d631b6b7ffdb870b6340324389) from AOSP so that you can use upstream directly when building build-tools.