### PR TITLE
Rust: use jemalloc for better performance

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -42,6 +42,7 @@ rust_binary_host {
     rustlibs: [
         "libkati",
         "libenv_logger",
+        "libtikv_jemallocator",
     ],
 }
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,6 +134,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
+name = "cc"
+version = "1.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16595d3be041c03b09d08d0858631facccee9221e579704070e6e9e4915d3bc7"
+dependencies = [
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -416,6 +425,7 @@ dependencies = [
  "memchr",
  "os_pipe",
  "parking_lot",
+ "tikv-jemallocator",
 ]
 
 [[package]]
@@ -715,6 +725,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "smallvec"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -729,6 +745,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cec5ff18518d81584f477e9bfdf957f5bb0979b0bac3af4ca30b5b3ae2d2865"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ log = "0.4.27"
 memchr = "2.7.4"
 os_pipe = "1.2.1"
 parking_lot = { version = "0.12.3" }
+tikv-jemallocator = "0.6.0"
 
 [features]
 gperf = ["dep:gperftools"]

--- a/src-rs/main.rs
+++ b/src-rs/main.rs
@@ -52,6 +52,15 @@ use kati::flags::FLAGS;
 use kati::symtab::{Symbol, intern, join_symbols};
 use kati::timeutil::ScopedTimeReporter;
 
+#[cfg(not(feature = "gperf"))]
+use tikv_jemallocator::Jemalloc;
+
+// Use jemalloc for better performance, but gperftools will use tcmalloc for
+// heap debugging.
+#[cfg(not(feature = "gperf"))]
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
+
 fn read_bootstrap_makefile(targets: &[Symbol]) -> Result<Arc<Mutex<Vec<Stmt>>>> {
     let mut bootstrap = BytesMut::new();
     bootstrap.put_slice(b"CC?=cc\n");


### PR DESCRIPTION
Making gperftools optional actually reduced performance a decent amount (1+ minutes). It turns out that when the heap debugging feature is enabled, gperftools will switch the global allocator to tcmalloc. We can gain back that performance by switching to jemalloc.

jemalloc is available in the Android tree, unlike tcmalloc.