### PR TITLE
Handle incomplete reads.

### DIFF
--- a/src/file.cc
+++ b/src/file.cc
@@ -42,11 +42,14 @@ Makefile::Makefile(const std::string& filename)
   mtime_ = st.st_mtime;
   buf_.resize(len);
   exists_ = true;
-  ssize_t r = HANDLE_EINTR(read(fd, &buf_[0], len));
-  if (r != static_cast<ssize_t>(len)) {
-    if (r < 0)
+  size_t remaining = len;
+  while (remaining > 0) {
+    size_t completed = len - remaining;
+    ssize_t r = HANDLE_EINTR(read(fd, &buf_[completed], remaining));
+    if (r == -1) {
       PERROR("read failed for %s", filename.c_str());
-    ERROR("Unexpected read length=%zd expected=%zu", r, len);
+    }
+    remaining -= r;
   }
 
   if (close(fd) < 0) {


### PR DESCRIPTION
man 2 read says:

> On  success,  the number of bytes read is returned (zero indicates end of file), and the file position is advanced by this number. It is not an error if this number is smaller than the number of bytes requested; this may happen for example because fewer bytes are actually available right now (maybe because we were close to end-of-file, or because we are reading from a pipe, or from a terminal), or because read() was interrupted by a signal. See also NOTES.
>
> **NOTES**
>
> On Linux, read() (and similar system calls) will transfer at most 0x7ffff000 (2,147,479,552) bytes, returning the number of bytes actually transferred.  (This is true on both 32-bit and 64-bit systems.)

Call `read()` in a loop to accommodate incomplete reads.