### PR TITLE
Add missing algorithm header file for exec.cc

### DIFF
--- a/src/exec.cc
+++ b/src/exec.cc
@@ -20,7 +20,7 @@
 #include <stdlib.h>
 #include <sys/wait.h>
 
-#include <memory>
+#include <cstdint>
 #include <string_view>
 #include <unordered_map>
 #include <utility>


### PR DESCRIPTION
memory is unused, remove it
Fix
src/exec.cc:129:3: error: ‘uint64_t’ does not name a type
