### PR TITLE
Add missing header files cstdint for uint64

### DIFF
--- a/src/exec.cc
+++ b/src/exec.cc
@@ -20,7 +20,7 @@
 #include <stdlib.h>
 #include <sys/wait.h>
 
-#include <memory>
+#include <cstdint>
 #include <string_view>
 #include <unordered_map>
 #include <utility>


### PR DESCRIPTION
Reproduce:

```sh
$ cd kati
$ make
g++ -c -std=c++17 -g -W -Wall -MMD -MP -O -DNOLOG -march=native -o out/affinity.o src/affinity.cc
g++ -c -std=c++17 -g -W -Wall -MMD -MP -O -DNOLOG -march=native -o out/command.o src/command.cc
g++ -c -std=c++17 -g -W -Wall -MMD -MP -O -DNOLOG -march=native -o out/dep.o src/dep.cc
g++ -c -std=c++17 -g -W -Wall -MMD -MP -O -DNOLOG -march=native -o out/eval.o src/eval.cc
g++ -c -std=c++17 -g -W -Wall -MMD -MP -O -DNOLOG -march=native -o out/exec.o src/exec.cc
src/exec.cc:129:3: error: ‘uint64_t’ does not name a type
  129 |   uint64_t Count() { return num_commands_; }
      |   ^~~~~~~~
src/exec.cc:39:1: note: ‘uint64_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
   38 | #include "var.h"
  +++ |+#include <cstdint>
   39 |
src/exec.cc:136:3: error: ‘uint64_t’ does not name a type
  136 |   uint64_t num_commands_;
      |   ^~~~~~~~
src/exec.cc:136:3: note: ‘uint64_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
src/exec.cc: In constructor ‘{anonymous}::Executor::Executor(Evaluator*)’:
src/exec.cc:47:47: error: class ‘{anonymous}::Executor’ does not have any field named ‘num_commands_’
   47 |   explicit Executor(Evaluator* ev) : ce_(ev), num_commands_(0) {
      |                                               ^~~~~~~~~~~~~
src/exec.cc: In member function ‘double {anonymous}::Executor::ExecNode(const DepNode&, const char*)’:
src/exec.cc:102:7: error: ‘num_commands_’ was not declared in this scope; did you mean ‘commands’?
  102 |       num_commands_ += 1;
      |       ^~~~~~~~~~~~~
      |       commands
src/exec.cc: In function ‘void Exec(const std::vector<std::pair<Symbol, DepNode*> >&, Evaluator*)’:
src/exec.cc:146:16: error: ‘class {anonymous}::Executor’ has no member named ‘Count’
  146 |   if (executor.Count() == 0) {
      |                ^~~~~
make: *** [Makefile.ckati:89: out/exec.o] Error 1
```
