### PR TITLE
Fix integer underflow in append_subst

### DIFF
--- a/src-rs/bins/find_emulator.rs
+++ b/src-rs/bins/find_emulator.rs
@@ -32,12 +32,12 @@ fn main() -> Result<()> {
 
     let cmd = Bytes::from(cmd.as_bytes().to_vec());
     let Some(fc) = parse(&cmd)? else {
-        log::error!("Unsupported command: {:?}", cmd);
+        log::error!("Unsupported command: {cmd:?}");
         std::process::exit(1);
     };
 
     let Some(output) = find(&cmd, &fc, &kati::loc::Loc::default())? else {
-        log::error!("Unable to run command {:?}", cmd);
+        log::error!("Unable to run command {cmd:?}");
         std::process::exit(1);
     };
 

--- a/src-rs/eval.rs
+++ b/src-rs/eval.rs
@@ -1010,7 +1010,7 @@ impl Evaluator {
         writeln!(tf, "    {{")?;
         writeln!(tf, "      \"name\": \"{name}\",")?;
         writeln!(tf, "      \"operation\": \"assign\",")?;
-        write!(tf, "      \"value\": \"{:?}\"", var)?;
+        write!(tf, "      \"value\": \"{var:?}\"")?;
         if let Some(definition) = var.read().definition().clone() {
             writeln!(tf, ",\n")?;
             writeln!(tf, "      \"value_stack\": [")?;

--- a/src-rs/func.rs
+++ b/src-rs/func.rs
@@ -733,7 +733,7 @@ fn call_func(args: &[Arc<Value>], ev: &mut Evaluator, out: &mut dyn BufMut) -> R
     let mut sv = Vec::new();
     let mut i = 1;
     loop {
-        let tmpvar_name_sym = intern(format!("{}", i));
+        let tmpvar_name_sym = intern(format!("{i}"));
         if let Some(a) = av.get(i - 1) {
             sv.push(ScopedGlobalVar::new(tmpvar_name_sym, a.clone())?);
         } else {

--- a/src-rs/main.rs
+++ b/src-rs/main.rs
@@ -338,7 +338,7 @@ fn main() {
             // run. This tool flag only dumps information, and doesn't run the rest of
             // kati.
             if let Err(err) = stamp_dump_main() {
-                eprintln!("{}", err);
+                eprintln!("{err}");
                 std::process::exit(1);
             }
             return;
@@ -381,7 +381,7 @@ fn main() {
         Ok(ret) => ret,
         Err(err) => {
             for cause in err.chain() {
-                eprintln!("{}", cause);
+                eprintln!("{cause}");
             }
             1
         }

--- a/src-rs/strutil.rs
+++ b/src-rs/strutil.rs
@@ -161,7 +161,7 @@ impl Pattern {
             if let Some(subst_percent_index) = memchr(b'%', subst) {
                 let mut ret = BytesMut::with_capacity(subst.len() + s.len() - self.pat.len() + 1);
                 ret.put_slice(&subst[..subst_percent_index]);
-                ret.put_slice(&s[percent_index..(percent_index + s.len() - self.pat.len() + 1)]);
+                ret.put_slice(&s[percent_index..(percent_index + s.len() + 1 - self.pat.len())]);
                 ret.put_slice(&subst[subst_percent_index + 1..]);
                 return ret.into();
             }
@@ -555,6 +555,7 @@ mod test {
         assert_eq!(subst_pattern(b"x.c", b"x.c", b"OK"), "OK");
         assert_eq!(subst_pattern(b"x.c.c", b"x.c", b"XX"), "x.c.c");
         assert_eq!(subst_pattern(b"x.x.c", b"x.c", b"XX"), "x.x.c");
+        assert_eq!(subst_pattern(b"/", b"%/", b"%"), "");
     }
 
     #[test]


### PR DESCRIPTION
Even though it would immediately re-overflow into a valid value, apparently we have the rust overflow checks enabled on release builds in android, causing crashes.

Also fix clippy errors.
