### PR TITLE
Fix rkati not using find emulator when checking stamp file

### DIFF
--- a/src-rs/func.rs
+++ b/src-rs/func.rs
@@ -667,7 +667,11 @@ fn shell_func(args: &[Arc<Value>], ev: &mut Evaluator, out: &mut dyn BufMut) -> 
     out.put_slice(&output);
     if should_store_command_result(&cmd) {
         COMMAND_RESULTS.lock().push(CommandResult {
-            op: CommandOp::Shell,
+            op: if fc.is_some() {
+                CommandOp::Find
+            } else {
+                CommandOp::Shell
+            },
             shell,
             shellflag: Bytes::from_static(shellflag),
             cmd,

--- a/testcase/ninja_regen_find_with_invalid_globs.sh
+++ b/testcase/ninja_regen_find_with_invalid_globs.sh
@@ -1,0 +1,40 @@
+set -euo pipefail
+
+mk="$@"
+
+# This tests behavior for a bug in the find emulator:
+# The *.xml and .* are not expanded despite not being quoted. So if the find emulator
+# weren't used, the find would fail with invalid arguments. Probably should fix this
+# in the future
+
+mkdir -p bootable/recovery/tools/recovery_l10n/res/values/
+mkdir -p bootable/recovery/tools/recovery_l10n/res/layout/
+touch bootable/recovery/tools/recovery_l10n/res/values/strings.xml
+touch bootable/recovery/tools/recovery_l10n/res/layout/main.xml
+touch .cursorignore
+touch .gemini
+touch .repo
+
+if echo "${mk}" | grep kati > /dev/null; then
+  mk="${mk} --use_find_emulator"
+fi
+
+cat <<EOF > Makefile
+resource_dir := bootable/recovery/tools/recovery_l10n/res/
+resource_dir_deps := \$(sort \$(shell find \$(resource_dir) -name *.xml -not -name .*))
+all: \$(resource_dir_deps)
+	@echo Hello, world!
+EOF
+
+${mk} 2>stderr_log
+if [ -e ninja.sh ]; then
+  ./ninja.sh
+fi
+
+${mk} 2>stderr_log2
+if [ -e ninja.sh ]; then
+  if grep regenerating stderr_log2 > /dev/null; then
+    echo 'Should not regenerate'
+  fi
+  ./ninja.sh
+fi


### PR DESCRIPTION
It was not recording shells as find emulator commands when writing the stamp file. This was causing extraneous reanalysis because the find emulator results that were ran the first time differ from running the find command as a regular shell command, which happened the second time.