### PR TITLE
Revert "Replace OsStr's .display() with .to_string_lossy()"

### DIFF
--- a/src-rs/regen_dump.rs
+++ b/src-rs/regen_dump.rs
@@ -88,7 +88,7 @@ fn inner(
         let files = load_vec_string(fp)?;
         if dump_files {
             for file in files {
-                println!("{}", file.to_string_lossy());
+                println!("{}", file.display());
             }
         }
     }
@@ -97,7 +97,7 @@ fn inner(
         let undefined = load_vec_string(fp)?;
         if dump_env {
             for var in undefined {
-                println!("undefined: {}", var.to_string_lossy());
+                println!("undefined: {}", var.display());
             }
         }
     }
@@ -107,7 +107,7 @@ fn inner(
         let name = load_string(fp)?;
         let value = load_string(fp)?;
         if dump_env {
-            println!("{}: {}", name.to_string_lossy(), value.to_string_lossy());
+            println!("{}: {}", name.display(), value.display());
         }
     }
 
@@ -117,10 +117,10 @@ fn inner(
 
         let files = load_vec_string(fp)?;
         if dump_globs {
-            println!("{}", pat.to_string_lossy());
+            println!("{}", pat.display());
 
             for s in files {
-                println!("  {}", s.to_string_lossy());
+                println!("  {}", s.display());
             }
         }
     }
@@ -145,26 +145,26 @@ fn inner(
 
             if dump_finds {
                 println!("cmd type: FIND");
-                println!("  shell: {}", shell.to_string_lossy());
-                println!("  shell flagss: {}", shellflag.to_string_lossy());
-                println!("  loc: {}:{line}", file.to_string_lossy());
-                println!("  cmd: {}", cmd.to_string_lossy());
+                println!("  shell: {}", shell.display());
+                println!("  shell flagss: {}", shellflag.display());
+                println!("  loc: {}:{line}", file.display());
+                println!("  cmd: {}", cmd.display());
                 if !result.is_empty() && result.len() < 500 && !result.as_bytes().contains(&b'\n') {
-                    println!("  output: {}", result.to_string_lossy());
+                    println!("  output: {}", result.display());
                 } else {
                     println!("  output: <{} bytes>", result.len());
                 }
                 println!("  missing dirs:");
                 for d in missing_dirs {
-                    println!("    {}", d.to_string_lossy());
+                    println!("    {}", d.display());
                 }
                 println!("  files:");
                 for f in files {
-                    println!("    {}", f.to_string_lossy());
+                    println!("    {}", f.display());
                 }
                 println!("  read dirs:");
                 for d in read_dirs {
-                    println!("    {}", d.to_string_lossy());
+                    println!("    {}", d.display());
                 }
                 println!();
             }
@@ -172,8 +172,8 @@ fn inner(
             match op {
                 CommandOp::Shell => {
                     println!("cmd type: SHELL");
-                    println!("  shell: {}", shell.to_string_lossy());
-                    println!("  shell flagss: {}", shellflag.to_string_lossy());
+                    println!("  shell: {}", shell.display());
+                    println!("  shell flagss: {}", shellflag.display());
                 }
                 CommandOp::Read => println!("cmd type: READ"),
                 CommandOp::ReadMissing => println!("cmd type: READ_MISSING"),
@@ -181,10 +181,10 @@ fn inner(
                 CommandOp::Append => println!("cmd type: APPEND"),
                 CommandOp::Find => unreachable!(),
             }
-            println!("  loc: {}:{line}", file.to_string_lossy());
-            println!("  cmd: {}", cmd.to_string_lossy());
+            println!("  loc: {}:{line}", file.display());
+            println!("  cmd: {}", cmd.display());
             if !result.is_empty() && result.len() < 500 && !result.as_bytes().contains(&b'\n') {
-                println!("  output: {}", result.to_string_lossy());
+                println!("  output: {}", result.display());
             } else {
                 println!("  output: <{} bytes>", result.len());
             }


### PR DESCRIPTION
This reverts commit 784e212f0afc014f91d196df502e48641546a8b8.

Android is now on Rust 1.87.0