### PR TITLE
Make jemalloc optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,10 @@ os_pipe = "1.2.1"
 parking_lot = { version = "0.12.3" }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-tikv-jemallocator = "0.6.0"
+tikv-jemallocator = { version = "0.6.0", optional = true }
 
 [features]
+jemalloc = ["tikv-jemallocator"]
 gperf = ["dep:gperftools"]
 
 [[bin]]

--- a/src-rs/main.rs
+++ b/src-rs/main.rs
@@ -52,12 +52,12 @@ use kati::flags::FLAGS;
 use kati::symtab::{Symbol, intern, join_symbols};
 use kati::timeutil::ScopedTimeReporter;
 
-#[cfg(all(not(feature = "gperf"), target_os = "linux"))]
+#[cfg(all(not(feature = "gperf"), target_os = "linux", feature = "jemalloc"))]
 use tikv_jemallocator::Jemalloc;
 
 // Use jemalloc for better performance, but gperftools will use tcmalloc for
 // heap debugging.
-#[cfg(all(not(feature = "gperf"), target_os = "linux"))]
+#[cfg(all(not(feature = "gperf"), target_os = "linux", feature = "jemalloc"))]
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
 


### PR DESCRIPTION
Upstream jemalloc is archived, and although there is a new fork by facebook it has no releases. Jemalloc causes issues on systems with a global allocator such as mimalloc, and on (aarch64) systems with a page size such as 16k or 64k. See https://github.com/tikv/jemallocator/issues/122. Maybe it could be removed entirely from this crate but I don't know if this is desired.